### PR TITLE
Better start detection

### DIFF
--- a/Scripts/LiveSplit.Darksiders.asl
+++ b/Scripts/LiveSplit.Darksiders.asl
@@ -6,7 +6,7 @@ state("DarksidersPC")
 
 start
 {
-	return current.time != 0;
+	return current.time == 1;
 }
 
 split


### PR DESCRIPTION
!= 0 wasn't really clever as loading a save would start the timer.
==1 is way better because the only way it starts the timer is when the ingame timer starts increasing from 0.
