### PR TITLE
Fix Invalid Pointer Errors

### DIFF
--- a/DeepPtr.cs
+++ b/DeepPtr.cs
@@ -203,7 +203,10 @@ namespace LiveSplit
             }
             else if (type == typeof(bool))
             {
-                val = (object)BitConverter.ToBoolean(bytes, 0);
+                if (bytes == null)
+                    val = false;
+                else
+                    val = (object)BitConverter.ToBoolean(bytes, 0);
             }
             else if (type == typeof(short))
             {


### PR DESCRIPTION
If a bool points to an invalid memory region, it now returns false instead of throwing an error. Only using a bool as it makes the most sense of any type.