### PR TITLE
Make module definition optional

### DIFF
--- a/ASL/ASLGrammar.cs
+++ b/ASL/ASLGrammar.cs
@@ -3,6 +3,7 @@ using System.Linq;
 
 namespace LiveSplit.ASL
 {
+    [Language("asl", "1.0", "Auto Split Language grammar")]
     public class ASLGrammar : Grammar
     {
         public ASLGrammar()
@@ -33,6 +34,7 @@ namespace LiveSplit.ASL
             var methodList = new NonTerminal("methodList");
             var varList = new NonTerminal("varList");
             var var = new NonTerminal("var");
+            var module = new NonTerminal("module");
             var method = new NonTerminal("method");
             var offsetList = new NonTerminal("offsetList");
             var offset = new NonTerminal("offset");
@@ -42,7 +44,8 @@ namespace LiveSplit.ASL
             stateDef.Rule = state + "(" + stringLit + ")" + "{" + varList + "}";
             methodList.Rule = MakeStarRule(methodList, method);
             varList.Rule = MakeStarRule(varList, semi, var);
-            var.Rule = (identifier + identifier + ":" + stringLit + comma + offsetList) | Empty;
+            module.Rule = (stringLit + comma) | Empty;
+            var.Rule = (identifier + identifier + ":" + module + offsetList) | Empty;
             method.Rule = (methodType + "{" + code + "}") | Empty;
             offsetList.Rule = MakePlusRule(offsetList, comma, offset);
             offset.Rule = number;

--- a/ASL/ASLParser.cs
+++ b/ASL/ASLParser.cs
@@ -26,9 +26,9 @@ namespace LiveSplit.ASL
                 var childNodes = valueDefinitionNode.ChildNodes;
                 var type = (String)childNodes[0].Token.Value;
                 var identifier = (String)childNodes[1].Token.Value;
-                var module = (String)childNodes[3].Token.Value;
-                var moduleBase = childNodes[5].ChildNodes.Select(x => (int)x.Token.Value).First();
-                var offsets = childNodes[5].ChildNodes.Skip(1).Select(x => (int)x.Token.Value).ToArray();
+                var module = childNodes[3].ChildNodes.Take(1).Select(x => (String)x.Token.Value).FirstOrDefault() ?? String.Empty;
+                var moduleBase = childNodes[4].ChildNodes.Select(x => (int)x.Token.Value).First();
+                var offsets = childNodes[4].ChildNodes.Skip(1).Select(x => (int)x.Token.Value).ToArray();
                 var valueDefinition = new ASLValueDefinition() 
                 { 
                     Identifier = identifier,


### PR DESCRIPTION
defining the module is only required when it's a dll

state("game")
{
	int test : "game.exe", 0x12, 0x12; // old
	int test2 : "", 0x12, 0x12; // old (works)
	int test3 : 0x12, 0x12; // new
}