### PR TITLE
Check if process has exited at selection

### DIFF
--- a/ASL/ASLScript.cs
+++ b/ASL/ASLScript.cs
@@ -70,7 +70,7 @@ namespace LiveSplit.ASL
                     // default to first defined state in file (lazy)
                     // TODO: default to the one with no version specified, if it exists
                     State = States[proccessName].First(),
-                    Process = Process.GetProcessesByName(proccessName).FirstOrDefault()
+                    Process = Process.GetProcessesByName(proccessName).FirstOrDefault(x => !x.HasExited)
                 }).FirstOrDefault(x => x.Process != null);
 
                 if (stateProcess != null)


### PR DESCRIPTION
This fixes an occasional bug where the game would stay in the process list even after exiting (often after crashing). The exited process would still be returned since it was not checked at selection.