### PR TITLE
ASL Settings and other tweaks

### DIFF
--- a/ASL/ASLGrammar.cs
+++ b/ASL/ASLGrammar.cs
@@ -24,6 +24,7 @@ namespace LiveSplit.ASL
             var start = new KeyTerm("start", "start");
             var split = new KeyTerm("split", "split");
             var reset = new KeyTerm("reset", "reset");
+            var settings = new KeyTerm("settings", "settings");
             var isLoading = new KeyTerm("isLoading", "isLoading");
             var gameTime = new KeyTerm("gameTime", "gameTime");
             var comma = ToTerm(",", "comma");
@@ -53,7 +54,7 @@ namespace LiveSplit.ASL
             method.Rule = (methodType + "{" + code + "}") | Empty;
             offsetList.Rule = MakePlusRule(offsetList, comma, offset);
             offset.Rule = number;
-            methodType.Rule = init | update | start | split | isLoading | gameTime | reset;
+            methodType.Rule = init | update | start | split | isLoading | gameTime | reset | settings;
 
             Root = root;
 

--- a/ASL/ASLGrammar.cs
+++ b/ASL/ASLGrammar.cs
@@ -24,7 +24,8 @@ namespace LiveSplit.ASL
             var start = new KeyTerm("start", "start");
             var split = new KeyTerm("split", "split");
             var reset = new KeyTerm("reset", "reset");
-            var settings = new KeyTerm("settings", "settings");
+            var startup = new KeyTerm("startup", "startup");
+            var shutdown = new KeyTerm("shutdown", "shutdown");
             var isLoading = new KeyTerm("isLoading", "isLoading");
             var gameTime = new KeyTerm("gameTime", "gameTime");
             var comma = ToTerm(",", "comma");
@@ -54,7 +55,7 @@ namespace LiveSplit.ASL
             method.Rule = (methodType + "{" + code + "}") | Empty;
             offsetList.Rule = MakePlusRule(offsetList, comma, offset);
             offset.Rule = number;
-            methodType.Rule = init | update | start | split | isLoading | gameTime | reset | settings;
+            methodType.Rule = init | update | start | split | isLoading | gameTime | reset | startup | shutdown;
 
             Root = root;
 

--- a/ASL/ASLMethod.cs
+++ b/ASL/ASLMethod.cs
@@ -56,7 +56,7 @@ public class CompiledScript
 	    return null;
     }}
 
-    public dynamic Execute(LiveSplitState timer, dynamic vars, dynamic addSetting)
+    public dynamic Execute(LiveSplitState timer, dynamic vars, dynamic AddSetting)
     {{
 	    { codePreInit }
 	    return null;

--- a/ASL/ASLMethod.cs
+++ b/ASL/ASLMethod.cs
@@ -11,10 +11,19 @@ namespace LiveSplit.ASL
         protected dynamic CompiledCode { get; set; }
         public bool IsEmpty { get; }
 
-        public ASLMethod(string code)
+        public ASLMethod(string code) : this(code, false)
+        {
+
+        }
+
+        public ASLMethod(string code, bool preInit)
         {
             IsEmpty = string.IsNullOrWhiteSpace(code);
             code = code.Replace("return;", "return null;"); // hack
+
+            // Decide if this code already has access to the game
+            var codeRegular = preInit ? "" : code;
+            var codePreInit = preInit ? code : "";
 
             using (var provider =
                 new Microsoft.CSharp.CSharpCodeProvider(new Dictionary<string, string> { { "CompilerVersion", "v4.0" } }))
@@ -39,11 +48,17 @@ public class CompiledScript
     {{
         Trace.WriteLine(s);
     }}
-    public dynamic Execute(LiveSplitState timer, dynamic old, dynamic current, dynamic vars, Process game)
+    public dynamic Execute(LiveSplitState timer, dynamic old, dynamic current, dynamic vars, Process game, dynamic Enabled)
     {{
         var memory = game;
         var modules = game.ModulesWow64Safe();
-	    { code }
+	    { codeRegular }
+	    return null;
+    }}
+
+    public dynamic Execute(LiveSplitState timer, dynamic vars, dynamic addSetting)
+    {{
+	    { codePreInit }
 	    return null;
     }}
 }}";
@@ -81,15 +96,41 @@ public class CompiledScript
             }
         }
 
-        public dynamic Run(LiveSplitState timer, ASLState old, ASLState current, ExpandoObject vars, Process game, ref string version, ref double refreshRate)
+        public dynamic Run(LiveSplitState timer, ASLState old, ASLState current, ExpandoObject vars, Process game, ref string version, ref double refreshRate,
+            ASLSettings settings)
         {
             // dynamic args can't be ref or out, this is a workaround
             CompiledCode.version = version;
             CompiledCode.refreshRate = refreshRate;
-            var ret = CompiledCode.Execute(timer, old.Data, current.Data, vars, game);
+
+            Func<string, bool> getSetting = (name) =>
+            {
+                return settings.GetSettingValue(name);
+            };
+
+            var ret = CompiledCode.Execute(timer, old.Data, current.Data, vars, game, getSetting);
             version = CompiledCode.version;
             refreshRate = CompiledCode.refreshRate;
             return ret;
         }
+
+        public dynamic Run(LiveSplitState timer, ExpandoObject vars, ref string version, ref double refreshRate,
+            ASLSettings settings)
+        {
+            // dynamic args can't be ref or out, this is a workaround
+            CompiledCode.version = version;
+            CompiledCode.refreshRate = refreshRate;
+
+            Action<string, bool, string> addSetting = (name, value, label) =>
+            {
+                settings.AddSetting(name, value, label);
+            };
+
+            var ret = CompiledCode.Execute(timer, vars, addSetting);
+            version = CompiledCode.version;
+            refreshRate = CompiledCode.refreshRate;
+            return ret;
+        }
+
     }
 }

--- a/ASL/ASLMethod.cs
+++ b/ASL/ASLMethod.cs
@@ -48,7 +48,7 @@ public class CompiledScript
     {{
         Trace.WriteLine(s);
     }}
-    public dynamic Execute(LiveSplitState timer, dynamic old, dynamic current, dynamic vars, Process game, dynamic Enabled)
+    public dynamic Execute(LiveSplitState timer, dynamic old, dynamic current, dynamic vars, Process game, dynamic settings)
     {{
         var memory = game;
         var modules = game.ModulesWow64Safe();
@@ -56,7 +56,7 @@ public class CompiledScript
 	    return null;
     }}
 
-    public dynamic Execute(LiveSplitState timer, dynamic vars, dynamic AddSetting)
+    public dynamic Execute(LiveSplitState timer, dynamic vars, dynamic settings)
     {{
 	    { codePreInit }
 	    return null;
@@ -102,13 +102,7 @@ public class CompiledScript
             // dynamic args can't be ref or out, this is a workaround
             CompiledCode.version = version;
             CompiledCode.refreshRate = refreshRate;
-
-            Func<string, bool> getSetting = (name) =>
-            {
-                return settings.GetSettingValue(name);
-            };
-
-            var ret = CompiledCode.Execute(timer, old.Data, current.Data, vars, game, getSetting);
+            var ret = CompiledCode.Execute(timer, old.Data, current.Data, vars, game, settings.Reader);
             version = CompiledCode.version;
             refreshRate = CompiledCode.refreshRate;
             return ret;
@@ -120,13 +114,7 @@ public class CompiledScript
             // dynamic args can't be ref or out, this is a workaround
             CompiledCode.version = version;
             CompiledCode.refreshRate = refreshRate;
-
-            Action<string, bool, string> addSetting = (name, value, label) =>
-            {
-                settings.AddSetting(name, value, label);
-            };
-
-            var ret = CompiledCode.Execute(timer, vars, addSetting);
+            var ret = CompiledCode.Execute(timer, vars, settings.Builder);
             version = CompiledCode.version;
             refreshRate = CompiledCode.refreshRate;
             return ret;

--- a/ASL/ASLParser.cs
+++ b/ASL/ASLParser.cs
@@ -54,11 +54,12 @@ namespace LiveSplit.ASL
                 states[processName].Add(state);
             }
 
-            ASLMethod init = null, update = null, start = null, split = null, isLoading = null, gameTime = null, reset = null, settings = null;
+            ASLMethod init = null, update = null, start = null, split = null, isLoading = null, gameTime = null, reset = null,
+                startup = null, shutdown = null;
             foreach (var method in methodsNode.ChildNodes[0].ChildNodes)
             {
                 var methodName = (string)method.ChildNodes[0].Token.Value;
-                var script = new ASLMethod((string)method.ChildNodes[2].Token.Value, methodName == "settings");
+                var script = new ASLMethod((string)method.ChildNodes[2].Token.Value, methodName == "startup" || methodName == "shutdown");
                 switch (methodName)
                 {
                     case "init": init = script; break;
@@ -68,11 +69,12 @@ namespace LiveSplit.ASL
                     case "isLoading": isLoading = script; break;
                     case "gameTime": gameTime = script; break;
                     case "reset": reset = script; break;
-                    case "settings": settings = script; break;
+                    case "startup": startup = script; break;
+                    case "shutdown": shutdown = script; break;
                 }
             }
 
-            return new ASLScript(states, init, update, start, split, reset, isLoading, gameTime, settings);
+            return new ASLScript(states, init, update, start, split, reset, isLoading, gameTime, startup, shutdown);
         }
     }
 }

--- a/ASL/ASLParser.cs
+++ b/ASL/ASLParser.cs
@@ -54,11 +54,11 @@ namespace LiveSplit.ASL
                 states[processName].Add(state);
             }
 
-            ASLMethod init = null, update = null, start = null, split = null, isLoading = null, gameTime = null, reset = null;
+            ASLMethod init = null, update = null, start = null, split = null, isLoading = null, gameTime = null, reset = null, settings = null;
             foreach (var method in methodsNode.ChildNodes[0].ChildNodes)
             {
-                var script = new ASLMethod((string)method.ChildNodes[2].Token.Value);
                 var methodName = (string)method.ChildNodes[0].Token.Value;
+                var script = new ASLMethod((string)method.ChildNodes[2].Token.Value, methodName == "settings");
                 switch (methodName)
                 {
                     case "init": init = script; break;
@@ -67,11 +67,12 @@ namespace LiveSplit.ASL
                     case "split": split = script; break;
                     case "isLoading": isLoading = script; break;
                     case "gameTime": gameTime = script; break;
-                    case "reset": reset = script; break; 
+                    case "reset": reset = script; break;
+                    case "settings": settings = script; break;
                 }
             }
 
-            return new ASLScript(states, init, update, start, split, reset, isLoading, gameTime);
+            return new ASLScript(states, init, update, start, split, reset, isLoading, gameTime, settings);
         }
     }
 }

--- a/ASL/ASLScript.cs
+++ b/ASL/ASLScript.cs
@@ -69,15 +69,15 @@ namespace LiveSplit.ASL
 
             if (!Start.IsEmpty)
             {
-                Settings.AddMethodSetting("start");
+                Settings.AddBasicSetting("start");
             }
             if (!Split.IsEmpty)
             {
-                Settings.AddMethodSetting("split");
+                Settings.AddBasicSetting("split");
             }
             if (!Reset.IsEmpty)
             {
-                Settings.AddMethodSetting("reset");
+                Settings.AddBasicSetting("reset");
             }
 
             UsesGameTime = !IsLoading.IsEmpty || !GameTime.IsEmpty;
@@ -244,14 +244,14 @@ namespace LiveSplit.ASL
 
                 if (runMethod(Reset, lsState, ref ver) ?? false)
                 {
-                    if (Settings.MethodEnabled("reset"))
+                    if (Settings.GetBasicSettingValue("reset"))
                     {
                         Model.Reset();
                     }
                 }
                 else if (runMethod(Split, lsState, ref ver) ?? false)
                 {
-                    if (Settings.MethodEnabled("split"))
+                    if (Settings.GetBasicSettingValue("split"))
                     {
                         Model.Split();
                     }
@@ -262,7 +262,7 @@ namespace LiveSplit.ASL
             {
                 if (runMethod(Start, lsState, ref ver) ?? false)
                 {
-                    if (Settings.MethodEnabled("start"))
+                    if (Settings.GetBasicSettingValue("start"))
                     {
                         Model.Start();
                     }

--- a/ASL/ASLScript.cs
+++ b/ASL/ASLScript.cs
@@ -135,7 +135,7 @@ namespace LiveSplit.ASL
             return result;
         }
 
-        // Run startup and return settings defined in ASL script
+        // Run startup and return settings defined in ASL script.
         public ASLSettings RunStartup(LiveSplitState lsState)
         {
             debug("Running startup");

--- a/ASL/ASLSetting.cs
+++ b/ASL/ASLSetting.cs
@@ -1,5 +1,7 @@
 ﻿namespace LiveSplit.ASL
 {
+
+    // Created from the ASL script and shared with the GUI to synchronize setting state.
     public class ASLSetting
     {
         public string Name { get; set; }

--- a/ASL/ASLSetting.cs
+++ b/ASL/ASLSetting.cs
@@ -1,0 +1,21 @@
+﻿namespace LiveSplit.ASL
+{
+    public class ASLSetting
+    {
+        public string Name { get; set; }
+        public string Label { get; set; }
+        public bool Enabled { get; set; }
+
+        public ASLSetting(string name, bool defaultValue, string label)
+        {
+            Name = name;
+            Enabled = defaultValue;
+            Label = label;
+        }
+
+        public override string ToString()
+        {
+            return Label;
+        }
+    }
+}

--- a/ASL/ASLSetting.cs
+++ b/ASL/ASLSetting.cs
@@ -4,8 +4,8 @@
     // Created from the ASL script and shared with the GUI to synchronize setting state.
     public class ASLSetting
     {
-        public string Id { get; set; }
-        public string Label { get; set; }
+        public string Id { get; }
+        public string Label { get; }
         public bool Value { get; set; }
         public string Parent { get; }
 

--- a/ASL/ASLSetting.cs
+++ b/ASL/ASLSetting.cs
@@ -4,12 +4,12 @@
     {
         public string Name { get; set; }
         public string Label { get; set; }
-        public bool Enabled { get; set; }
+        public bool Value { get; set; }
 
         public ASLSetting(string name, bool defaultValue, string label)
         {
             Name = name;
-            Enabled = defaultValue;
+            Value = defaultValue;
             Label = label;
         }
 

--- a/ASL/ASLSetting.cs
+++ b/ASL/ASLSetting.cs
@@ -4,15 +4,17 @@
     // Created from the ASL script and shared with the GUI to synchronize setting state.
     public class ASLSetting
     {
-        public string Name { get; set; }
+        public string Id { get; set; }
         public string Label { get; set; }
         public bool Value { get; set; }
+        public string Parent { get; }
 
-        public ASLSetting(string name, bool defaultValue, string label)
+        public ASLSetting(string id, bool defaultValue, string label, string parent)
         {
-            Name = name;
+            Id = id;
             Value = defaultValue;
             Label = label;
+            Parent = parent;
         }
 
         public override string ToString()

--- a/ASL/ASLSettings.cs
+++ b/ASL/ASLSettings.cs
@@ -26,6 +26,10 @@ namespace LiveSplit.ASL
 
         public void AddSetting(string name, bool defaultValue, string description)
         {
+            if (description == null)
+            {
+                description = name;
+            }
             ASLSetting setting = new ASLSetting(name, defaultValue, description);
             Settings.Add(name, setting);
             OrderedSettings.Add(setting);
@@ -33,6 +37,8 @@ namespace LiveSplit.ASL
 
         public bool GetSettingValue(string name)
         {
+            // Don't cause error if setting doesn't exist, but still inform script
+            // author since that usually shouldn't happen.
             if (Settings.ContainsKey(name))
             {
                 return Settings[name].Value;

--- a/ASL/ASLSettings.cs
+++ b/ASL/ASLSettings.cs
@@ -8,21 +8,50 @@ namespace LiveSplit.ASL
 {
     public class ASLSettings
     {
+        // Dict for easy access per key
         public Dictionary<string, ASLSetting> Settings { get; set; }
+        // List for preserved insertion order (Dict provides that as well, but not guaranteed)
+        public List<ASLSetting> OrderedSettings { get; }
+
+        public Dictionary<string, ASLSetting> MethodSettings { get; }
+        
 
         public ASLSettings()
         {
             Settings = new Dictionary<string, ASLSetting>();
+            OrderedSettings = new List<ASLSetting>();
+            MethodSettings = new Dictionary<string, ASLSetting>();
         }
 
         public void AddSetting(string name, bool defaultValue, string description)
         {
-            Settings.Add(name, new ASLSetting(name, defaultValue, description));
+            ASLSetting setting = new ASLSetting(name, defaultValue, description);
+            Settings.Add(name, setting);
+            OrderedSettings.Add(setting);
         }
 
         public bool GetSettingValue(string name)
         {
-            return Settings[name].Enabled;
+            return Settings[name].Value;
+        }
+
+        public void AddMethodSetting(string name)
+        {
+            MethodSettings.Add(name, new ASLSetting(name, true, ""));
+        }
+
+        public bool MethodEnabled(string name)
+        {
+            if (MethodSettings.ContainsKey(name))
+            {
+                return MethodSettings[name].Value;
+            }
+            return false;
+        }
+
+        public bool MethodPresent(string name)
+        {
+            return MethodSettings.ContainsKey(name);
         }
 
 

--- a/ASL/ASLSettings.cs
+++ b/ASL/ASLSettings.cs
@@ -133,6 +133,30 @@ namespace LiveSplit.ASL
                 return s.GetSettingValue(id);
             }
         }
+
+        public bool StartEnabled
+        {
+            get
+            {
+                return s.GetBasicSettingValue("start");
+            }
+        }
+
+        public bool ResetEnabled
+        {
+            get
+            {
+                return s.GetBasicSettingValue("reset");
+            }
+        }
+
+        public bool SplitEnabled
+        {
+            get
+            {
+                return s.GetBasicSettingValue("split");
+            }
+        }
     }
 
 }

--- a/ASL/ASLSettings.cs
+++ b/ASL/ASLSettings.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -32,7 +33,12 @@ namespace LiveSplit.ASL
 
         public bool GetSettingValue(string name)
         {
-            return Settings[name].Value;
+            if (Settings.ContainsKey(name))
+            {
+                return Settings[name].Value;
+            }
+            Trace.WriteLine("[ASL] Custom Setting Key doesn't exist: "+name);
+            return false;
         }
 
         public void AddMethodSetting(string name)

--- a/ASL/ASLSettings.cs
+++ b/ASL/ASLSettings.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LiveSplit.ASL
+{
+    public class ASLSettings
+    {
+        public Dictionary<string, ASLSetting> Settings { get; set; }
+
+        public ASLSettings()
+        {
+            Settings = new Dictionary<string, ASLSetting>();
+        }
+
+        public void AddSetting(string name, bool defaultValue, string description)
+        {
+            Settings.Add(name, new ASLSetting(name, defaultValue, description));
+        }
+
+        public bool GetSettingValue(string name)
+        {
+            return Settings[name].Enabled;
+        }
+
+
+    }
+}

--- a/ASL/ASLSettings.cs
+++ b/ASL/ASLSettings.cs
@@ -14,23 +14,31 @@ namespace LiveSplit.ASL
         // List for preserved insertion order (Dict provides that as well, but not guaranteed)
         public List<ASLSetting> OrderedSettings { get; }
 
-        public Dictionary<string, ASLSetting> MethodSettings { get; }
-        
+        public Dictionary<string, ASLSetting> BasicSettings { get; }
 
+        public ASLSettingsBuilder Builder;
+        public ASLSettingsReader Reader;
+        
         public ASLSettings()
         {
             Settings = new Dictionary<string, ASLSetting>();
             OrderedSettings = new List<ASLSetting>();
-            MethodSettings = new Dictionary<string, ASLSetting>();
+            BasicSettings = new Dictionary<string, ASLSetting>();
+            Builder = new ASLSettingsBuilder(this);
+            Reader = new ASLSettingsReader(this);
         }
 
-        public void AddSetting(string name, bool defaultValue, string description)
+        public void AddSetting(string name, bool defaultValue, string description, string parent)
         {
             if (description == null)
             {
                 description = name;
             }
-            ASLSetting setting = new ASLSetting(name, defaultValue, description);
+            if (parent != null && !Settings.ContainsKey(parent))
+            {
+                throw new ArgumentException("Parent for setting '"+name+"' is not a setting: " + parent);
+            }
+            ASLSetting setting = new ASLSetting(name, defaultValue, description, parent);
             Settings.Add(name, setting);
             OrderedSettings.Add(setting);
         }
@@ -41,31 +49,90 @@ namespace LiveSplit.ASL
             // author since that usually shouldn't happen.
             if (Settings.ContainsKey(name))
             {
-                return Settings[name].Value;
+                return getSettingValueRecursive(Settings[name]);
             }
             Trace.WriteLine("[ASL] Custom Setting Key doesn't exist: "+name);
             return false;
         }
 
-        public void AddMethodSetting(string name)
+        /// <summary>
+        /// Returns true only if this setting and all it's parent settings are true.
+        /// </summary>
+        private bool getSettingValueRecursive(ASLSetting setting)
         {
-            MethodSettings.Add(name, new ASLSetting(name, true, ""));
+            if (!setting.Value)
+            {
+                return false;
+            }
+            if (setting.Parent == null)
+            {
+                return setting.Value;
+            }
+            return getSettingValueRecursive(Settings[setting.Parent]);
         }
 
-        public bool MethodEnabled(string name)
+        public void AddBasicSetting(string name)
         {
-            if (MethodSettings.ContainsKey(name))
+            BasicSettings.Add(name, new ASLSetting(name, true, "", null));
+        }
+
+        public bool GetBasicSettingValue(string name)
+        {
+            if (BasicSettings.ContainsKey(name))
             {
-                return MethodSettings[name].Value;
+                return BasicSettings[name].Value;
             }
             return false;
         }
 
-        public bool MethodPresent(string name)
+        public bool IsBasicSettingPresent(string name)
         {
-            return MethodSettings.ContainsKey(name);
+            return BasicSettings.ContainsKey(name);
+        }
+    }
+
+    /// <summary>
+    /// Interface for adding settings via the ASL Script.
+    /// </summary>
+    public class ASLSettingsBuilder
+    {
+        public string CurrentDefaultParent { get; set; }
+        ASLSettings s;
+
+        public ASLSettingsBuilder(ASLSettings s)
+        {
+            this.s = s;
         }
 
-
+        public void Add(string id, bool defaultValue = true, string description = null, string parent = null)
+        {
+            if (parent == null)
+            {
+                parent = CurrentDefaultParent;
+            }
+            s.AddSetting(id, defaultValue, description, parent);
+        }
     }
+
+    /// <summary>
+    /// Interface for reading settings via the ASL Script.
+    /// </summary>
+    public class ASLSettingsReader
+    {
+        ASLSettings s;
+
+        public ASLSettingsReader(ASLSettings s)
+        {
+            this.s = s;
+        }
+
+        public dynamic this[string id]
+        {
+            get
+            {
+                return s.GetSettingValue(id);
+            }
+        }
+    }
+
 }

--- a/Component.cs
+++ b/Component.cs
@@ -91,13 +91,17 @@ namespace LiveSplit.UI.Components
                     
                     // New script
                     Script = ASLParser.Parse(File.ReadAllText(Settings.ScriptPath));
+
                     Script.RefreshRateChanged += Script_RefreshRateChanged;
                     Script_RefreshRateChanged(this, Script.RefreshRate);
 
                     Script.GameVersionChanged += Script_GameVersionChanged;
                     Settings.SetGameVersion(null);
 
-                    Settings.SetASLSettings(Script.GetSettings(State));
+                    // Give custom ASL settings to GUI, which populates the list and
+                    // stores the ASLSetting objects which are shared between the GUI
+                    // and ASLScript
+                    Settings.SetASLSettings(Script.RunStartup(State));
                 }
                 catch (Exception ex)
                 {

--- a/ComponentSettings.Designer.cs
+++ b/ComponentSettings.Designer.cs
@@ -70,10 +70,9 @@
             this.tableLayoutPanel1.RowCount = 4;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(462, 523);
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(462, 498);
             this.tableLayoutPanel1.TabIndex = 0;
             // 
             // label1
@@ -107,15 +106,13 @@
             // 
             // customSettingsList
             // 
-            this.customSettingsList.CheckOnClick = true;
             this.tableLayoutPanel1.SetColumnSpan(this.customSettingsList, 2);
             this.customSettingsList.Dock = System.Windows.Forms.DockStyle.Fill;
             this.customSettingsList.FormattingEnabled = true;
             this.customSettingsList.HorizontalScrollbar = true;
-            this.customSettingsList.IntegralHeight = false;
             this.customSettingsList.Location = new System.Drawing.Point(79, 61);
             this.customSettingsList.Name = "customSettingsList";
-            this.customSettingsList.Size = new System.Drawing.Size(380, 424);
+            this.customSettingsList.Size = new System.Drawing.Size(380, 399);
             this.customSettingsList.TabIndex = 4;
             this.customSettingsList.ItemCheck += new System.Windows.Forms.ItemCheckEventHandler(this.customSettingsList_ItemCheck);
             // 
@@ -127,7 +124,7 @@
             this.flowLayoutPanel1.Controls.Add(this.checkAllButton);
             this.flowLayoutPanel1.Controls.Add(this.uncheckAllButton);
             this.flowLayoutPanel1.Controls.Add(this.resetToDefaultButton);
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(206, 491);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(206, 466);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
             this.flowLayoutPanel1.Size = new System.Drawing.Size(253, 29);
             this.flowLayoutPanel1.TabIndex = 8;
@@ -252,7 +249,7 @@
             this.Controls.Add(this.tableLayoutPanel1);
             this.Name = "ComponentSettings";
             this.Padding = new System.Windows.Forms.Padding(7);
-            this.Size = new System.Drawing.Size(476, 537);
+            this.Size = new System.Drawing.Size(476, 512);
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
             this.flowLayoutPanel1.ResumeLayout(false);

--- a/ComponentSettings.Designer.cs
+++ b/ComponentSettings.Designer.cs
@@ -41,7 +41,7 @@
             this.startCheckbox = new System.Windows.Forms.CheckBox();
             this.splitCheckbox = new System.Windows.Forms.CheckBox();
             this.resetCheckbox = new System.Windows.Forms.CheckBox();
-            this.gameVersion = new System.Windows.Forms.Label();
+            this.gameVersionLabel = new System.Windows.Forms.Label();
             this.optionsLabel = new System.Windows.Forms.Label();
             this.customSettingsLabel = new System.Windows.Forms.Label();
             this.tableLayoutPanel1.SuspendLayout();
@@ -170,7 +170,7 @@
             this.flowLayoutPanel2.Controls.Add(this.startCheckbox);
             this.flowLayoutPanel2.Controls.Add(this.splitCheckbox);
             this.flowLayoutPanel2.Controls.Add(this.resetCheckbox);
-            this.flowLayoutPanel2.Controls.Add(this.gameVersion);
+            this.flowLayoutPanel2.Controls.Add(this.gameVersionLabel);
             this.flowLayoutPanel2.Location = new System.Drawing.Point(79, 32);
             this.flowLayoutPanel2.Name = "flowLayoutPanel2";
             this.flowLayoutPanel2.Size = new System.Drawing.Size(380, 23);
@@ -212,15 +212,16 @@
             this.resetCheckbox.UseVisualStyleBackColor = true;
             this.resetCheckbox.CheckedChanged += new System.EventHandler(this.methodCheckbox_CheckedChanged);
             // 
-            // gameVersion
+            // gameVersionLabel
             // 
-            this.gameVersion.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.gameVersion.Location = new System.Drawing.Point(169, 5);
-            this.gameVersion.Name = "gameVersion";
-            this.gameVersion.Size = new System.Drawing.Size(208, 13);
-            this.gameVersion.TabIndex = 10;
-            this.gameVersion.Text = "Game Version: 1.0";
-            this.gameVersion.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.gameVersionLabel.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            this.gameVersionLabel.AutoEllipsis = true;
+            this.gameVersionLabel.Location = new System.Drawing.Point(169, 5);
+            this.gameVersionLabel.Name = "gameVersionLabel";
+            this.gameVersionLabel.Size = new System.Drawing.Size(208, 13);
+            this.gameVersionLabel.TabIndex = 10;
+            this.gameVersionLabel.Text = "Game Version: 1.0";
+            this.gameVersionLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // optionsLabel
             // 
@@ -272,7 +273,7 @@
         private System.Windows.Forms.Button uncheckAllButton;
         private System.Windows.Forms.Button resetToDefaultButton;
         private System.Windows.Forms.Label optionsLabel;
-        private System.Windows.Forms.Label gameVersion;
+        private System.Windows.Forms.Label gameVersionLabel;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel2;
         private System.Windows.Forms.CheckBox startCheckbox;
         private System.Windows.Forms.CheckBox resetCheckbox;

--- a/ComponentSettings.Designer.cs
+++ b/ComponentSettings.Designer.cs
@@ -124,9 +124,9 @@
             this.flowLayoutPanel1.Controls.Add(this.checkAllButton);
             this.flowLayoutPanel1.Controls.Add(this.uncheckAllButton);
             this.flowLayoutPanel1.Controls.Add(this.resetToDefaultButton);
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(206, 466);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(205, 466);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(253, 29);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(254, 29);
             this.flowLayoutPanel1.TabIndex = 8;
             // 
             // checkAllButton
@@ -135,7 +135,7 @@
             this.checkAllButton.Name = "checkAllButton";
             this.checkAllButton.Size = new System.Drawing.Size(62, 23);
             this.checkAllButton.TabIndex = 5;
-            this.checkAllButton.Text = "Check all";
+            this.checkAllButton.Text = "Check All";
             this.checkAllButton.UseVisualStyleBackColor = true;
             this.checkAllButton.Click += new System.EventHandler(this.checkAllButton_Click);
             // 
@@ -145,16 +145,16 @@
             this.uncheckAllButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.uncheckAllButton.Location = new System.Drawing.Point(71, 3);
             this.uncheckAllButton.Name = "uncheckAllButton";
-            this.uncheckAllButton.Size = new System.Drawing.Size(74, 23);
+            this.uncheckAllButton.Size = new System.Drawing.Size(75, 23);
             this.uncheckAllButton.TabIndex = 6;
-            this.uncheckAllButton.Text = "Uncheck all";
+            this.uncheckAllButton.Text = "Uncheck All";
             this.uncheckAllButton.UseVisualStyleBackColor = true;
             this.uncheckAllButton.Click += new System.EventHandler(this.uncheckAllButton_Click);
             // 
             // resetToDefaultButton
             // 
             this.resetToDefaultButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.resetToDefaultButton.Location = new System.Drawing.Point(151, 3);
+            this.resetToDefaultButton.Location = new System.Drawing.Point(152, 3);
             this.resetToDefaultButton.Name = "resetToDefaultButton";
             this.resetToDefaultButton.Size = new System.Drawing.Size(99, 23);
             this.resetToDefaultButton.TabIndex = 7;

--- a/ComponentSettings.Designer.cs
+++ b/ComponentSettings.Designer.cs
@@ -28,25 +28,31 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.label1 = new System.Windows.Forms.Label();
+            this.labelScriptPath = new System.Windows.Forms.Label();
             this.btnSelectFile = new System.Windows.Forms.Button();
             this.txtScriptPath = new System.Windows.Forms.TextBox();
-            this.customSettingsList = new System.Windows.Forms.CheckedListBox();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
-            this.checkAllButton = new System.Windows.Forms.Button();
-            this.uncheckAllButton = new System.Windows.Forms.Button();
-            this.resetToDefaultButton = new System.Windows.Forms.Button();
+            this.btnCheckAll = new System.Windows.Forms.Button();
+            this.btnUncheckAll = new System.Windows.Forms.Button();
+            this.btnResetToDefault = new System.Windows.Forms.Button();
             this.flowLayoutPanel2 = new System.Windows.Forms.FlowLayoutPanel();
-            this.startCheckbox = new System.Windows.Forms.CheckBox();
-            this.splitCheckbox = new System.Windows.Forms.CheckBox();
-            this.resetCheckbox = new System.Windows.Forms.CheckBox();
-            this.gameVersionLabel = new System.Windows.Forms.Label();
-            this.optionsLabel = new System.Windows.Forms.Label();
-            this.customSettingsLabel = new System.Windows.Forms.Label();
+            this.checkboxStart = new System.Windows.Forms.CheckBox();
+            this.checkboxSplit = new System.Windows.Forms.CheckBox();
+            this.checkboxReset = new System.Windows.Forms.CheckBox();
+            this.labelGameVersion = new System.Windows.Forms.Label();
+            this.labelOptions = new System.Windows.Forms.Label();
+            this.labelCustomSettings = new System.Windows.Forms.Label();
+            this.treeContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.cmiCheckBranch = new System.Windows.Forms.ToolStripMenuItem();
+            this.cmiUncheckBranch = new System.Windows.Forms.ToolStripMenuItem();
+            this.cmiResetBranchToDefault = new System.Windows.Forms.ToolStripMenuItem();
+            this.treeCustomSettings = new LiveSplit.UI.Components.NewTreeView();
             this.tableLayoutPanel1.SuspendLayout();
             this.flowLayoutPanel1.SuspendLayout();
             this.flowLayoutPanel2.SuspendLayout();
+            this.treeContextMenu.SuspendLayout();
             this.SuspendLayout();
             // 
             // tableLayoutPanel1
@@ -56,14 +62,14 @@
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 76F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.labelScriptPath, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.btnSelectFile, 2, 0);
             this.tableLayoutPanel1.Controls.Add(this.txtScriptPath, 1, 0);
-            this.tableLayoutPanel1.Controls.Add(this.customSettingsList, 1, 2);
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 1, 3);
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel2, 1, 1);
-            this.tableLayoutPanel1.Controls.Add(this.optionsLabel, 0, 1);
-            this.tableLayoutPanel1.Controls.Add(this.customSettingsLabel, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.labelOptions, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.labelCustomSettings, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.treeCustomSettings, 1, 2);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(7, 7);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
@@ -72,18 +78,19 @@
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanel1.Size = new System.Drawing.Size(462, 498);
             this.tableLayoutPanel1.TabIndex = 0;
             // 
-            // label1
+            // labelScriptPath
             // 
-            this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(3, 8);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(70, 13);
-            this.label1.TabIndex = 3;
-            this.label1.Text = "Script Path:";
+            this.labelScriptPath.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.labelScriptPath.AutoSize = true;
+            this.labelScriptPath.Location = new System.Drawing.Point(3, 8);
+            this.labelScriptPath.Name = "labelScriptPath";
+            this.labelScriptPath.Size = new System.Drawing.Size(70, 13);
+            this.labelScriptPath.TabIndex = 3;
+            this.labelScriptPath.Text = "Script Path:";
             // 
             // btnSelectFile
             // 
@@ -104,144 +111,173 @@
             this.txtScriptPath.Size = new System.Drawing.Size(300, 20);
             this.txtScriptPath.TabIndex = 0;
             // 
-            // customSettingsList
-            // 
-            this.tableLayoutPanel1.SetColumnSpan(this.customSettingsList, 2);
-            this.customSettingsList.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.customSettingsList.FormattingEnabled = true;
-            this.customSettingsList.HorizontalScrollbar = true;
-            this.customSettingsList.Location = new System.Drawing.Point(79, 61);
-            this.customSettingsList.Name = "customSettingsList";
-            this.customSettingsList.Size = new System.Drawing.Size(380, 399);
-            this.customSettingsList.TabIndex = 4;
-            this.customSettingsList.ItemCheck += new System.Windows.Forms.ItemCheckEventHandler(this.customSettingsList_ItemCheck);
-            // 
             // flowLayoutPanel1
             // 
             this.flowLayoutPanel1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.flowLayoutPanel1.AutoSize = true;
             this.tableLayoutPanel1.SetColumnSpan(this.flowLayoutPanel1, 2);
-            this.flowLayoutPanel1.Controls.Add(this.checkAllButton);
-            this.flowLayoutPanel1.Controls.Add(this.uncheckAllButton);
-            this.flowLayoutPanel1.Controls.Add(this.resetToDefaultButton);
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(205, 466);
+            this.flowLayoutPanel1.Controls.Add(this.btnCheckAll);
+            this.flowLayoutPanel1.Controls.Add(this.btnUncheckAll);
+            this.flowLayoutPanel1.Controls.Add(this.btnResetToDefault);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(205, 457);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
             this.flowLayoutPanel1.Size = new System.Drawing.Size(254, 29);
             this.flowLayoutPanel1.TabIndex = 8;
             // 
-            // checkAllButton
+            // btnCheckAll
             // 
-            this.checkAllButton.Location = new System.Drawing.Point(3, 3);
-            this.checkAllButton.Name = "checkAllButton";
-            this.checkAllButton.Size = new System.Drawing.Size(62, 23);
-            this.checkAllButton.TabIndex = 5;
-            this.checkAllButton.Text = "Check All";
-            this.checkAllButton.UseVisualStyleBackColor = true;
-            this.checkAllButton.Click += new System.EventHandler(this.checkAllButton_Click);
+            this.btnCheckAll.Location = new System.Drawing.Point(3, 3);
+            this.btnCheckAll.Name = "btnCheckAll";
+            this.btnCheckAll.Size = new System.Drawing.Size(62, 23);
+            this.btnCheckAll.TabIndex = 5;
+            this.btnCheckAll.Text = "Check All";
+            this.btnCheckAll.UseVisualStyleBackColor = true;
+            this.btnCheckAll.Click += new System.EventHandler(this.btnCheckAll_Click);
             // 
-            // uncheckAllButton
+            // btnUncheckAll
             // 
-            this.uncheckAllButton.AutoSize = true;
-            this.uncheckAllButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.uncheckAllButton.Location = new System.Drawing.Point(71, 3);
-            this.uncheckAllButton.Name = "uncheckAllButton";
-            this.uncheckAllButton.Size = new System.Drawing.Size(75, 23);
-            this.uncheckAllButton.TabIndex = 6;
-            this.uncheckAllButton.Text = "Uncheck All";
-            this.uncheckAllButton.UseVisualStyleBackColor = true;
-            this.uncheckAllButton.Click += new System.EventHandler(this.uncheckAllButton_Click);
+            this.btnUncheckAll.AutoSize = true;
+            this.btnUncheckAll.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.btnUncheckAll.Location = new System.Drawing.Point(71, 3);
+            this.btnUncheckAll.Name = "btnUncheckAll";
+            this.btnUncheckAll.Size = new System.Drawing.Size(75, 23);
+            this.btnUncheckAll.TabIndex = 6;
+            this.btnUncheckAll.Text = "Uncheck All";
+            this.btnUncheckAll.UseVisualStyleBackColor = true;
+            this.btnUncheckAll.Click += new System.EventHandler(this.btnUncheckAll_Click);
             // 
-            // resetToDefaultButton
+            // btnResetToDefault
             // 
-            this.resetToDefaultButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.resetToDefaultButton.Location = new System.Drawing.Point(152, 3);
-            this.resetToDefaultButton.Name = "resetToDefaultButton";
-            this.resetToDefaultButton.Size = new System.Drawing.Size(99, 23);
-            this.resetToDefaultButton.TabIndex = 7;
-            this.resetToDefaultButton.Text = "Reset to default";
-            this.resetToDefaultButton.UseVisualStyleBackColor = true;
-            this.resetToDefaultButton.Click += new System.EventHandler(this.resetToDefaultButton_Click);
+            this.btnResetToDefault.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnResetToDefault.Location = new System.Drawing.Point(152, 3);
+            this.btnResetToDefault.Name = "btnResetToDefault";
+            this.btnResetToDefault.Size = new System.Drawing.Size(99, 23);
+            this.btnResetToDefault.TabIndex = 7;
+            this.btnResetToDefault.Text = "Reset to default";
+            this.btnResetToDefault.UseVisualStyleBackColor = true;
+            this.btnResetToDefault.Click += new System.EventHandler(this.btnResetToDefault_Click);
             // 
             // flowLayoutPanel2
             // 
             this.flowLayoutPanel2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.flowLayoutPanel2.AutoSize = true;
             this.tableLayoutPanel1.SetColumnSpan(this.flowLayoutPanel2, 2);
-            this.flowLayoutPanel2.Controls.Add(this.startCheckbox);
-            this.flowLayoutPanel2.Controls.Add(this.splitCheckbox);
-            this.flowLayoutPanel2.Controls.Add(this.resetCheckbox);
-            this.flowLayoutPanel2.Controls.Add(this.gameVersionLabel);
+            this.flowLayoutPanel2.Controls.Add(this.checkboxStart);
+            this.flowLayoutPanel2.Controls.Add(this.checkboxSplit);
+            this.flowLayoutPanel2.Controls.Add(this.checkboxReset);
+            this.flowLayoutPanel2.Controls.Add(this.labelGameVersion);
             this.flowLayoutPanel2.Location = new System.Drawing.Point(79, 32);
             this.flowLayoutPanel2.Name = "flowLayoutPanel2";
             this.flowLayoutPanel2.Size = new System.Drawing.Size(380, 23);
             this.flowLayoutPanel2.TabIndex = 12;
             // 
-            // startCheckbox
+            // checkboxStart
             // 
-            this.startCheckbox.Checked = true;
-            this.startCheckbox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.startCheckbox.Location = new System.Drawing.Point(3, 3);
-            this.startCheckbox.Name = "startCheckbox";
-            this.startCheckbox.Size = new System.Drawing.Size(48, 17);
-            this.startCheckbox.TabIndex = 11;
-            this.startCheckbox.Text = "Start";
-            this.startCheckbox.UseVisualStyleBackColor = true;
-            this.startCheckbox.CheckedChanged += new System.EventHandler(this.methodCheckbox_CheckedChanged);
+            this.checkboxStart.Enabled = false;
+            this.checkboxStart.Location = new System.Drawing.Point(3, 3);
+            this.checkboxStart.Name = "checkboxStart";
+            this.checkboxStart.Size = new System.Drawing.Size(48, 17);
+            this.checkboxStart.TabIndex = 11;
+            this.checkboxStart.Text = "Start";
+            this.checkboxStart.UseVisualStyleBackColor = true;
+            this.checkboxStart.CheckedChanged += new System.EventHandler(this.methodCheckbox_CheckedChanged);
             // 
-            // splitCheckbox
+            // checkboxSplit
             // 
-            this.splitCheckbox.Checked = true;
-            this.splitCheckbox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.splitCheckbox.Location = new System.Drawing.Point(57, 3);
-            this.splitCheckbox.Name = "splitCheckbox";
-            this.splitCheckbox.Size = new System.Drawing.Size(46, 17);
-            this.splitCheckbox.TabIndex = 0;
-            this.splitCheckbox.Text = "Split";
-            this.splitCheckbox.UseVisualStyleBackColor = true;
-            this.splitCheckbox.CheckedChanged += new System.EventHandler(this.methodCheckbox_CheckedChanged);
+            this.checkboxSplit.Enabled = false;
+            this.checkboxSplit.Location = new System.Drawing.Point(57, 3);
+            this.checkboxSplit.Name = "checkboxSplit";
+            this.checkboxSplit.Size = new System.Drawing.Size(46, 17);
+            this.checkboxSplit.TabIndex = 0;
+            this.checkboxSplit.Text = "Split";
+            this.checkboxSplit.UseVisualStyleBackColor = true;
+            this.checkboxSplit.CheckedChanged += new System.EventHandler(this.methodCheckbox_CheckedChanged);
             // 
-            // resetCheckbox
+            // checkboxReset
             // 
-            this.resetCheckbox.Checked = true;
-            this.resetCheckbox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.resetCheckbox.Location = new System.Drawing.Point(109, 3);
-            this.resetCheckbox.Name = "resetCheckbox";
-            this.resetCheckbox.Size = new System.Drawing.Size(54, 17);
-            this.resetCheckbox.TabIndex = 0;
-            this.resetCheckbox.Text = "Reset";
-            this.resetCheckbox.UseVisualStyleBackColor = true;
-            this.resetCheckbox.CheckedChanged += new System.EventHandler(this.methodCheckbox_CheckedChanged);
+            this.checkboxReset.Enabled = false;
+            this.checkboxReset.Location = new System.Drawing.Point(109, 3);
+            this.checkboxReset.Name = "checkboxReset";
+            this.checkboxReset.Size = new System.Drawing.Size(54, 17);
+            this.checkboxReset.TabIndex = 0;
+            this.checkboxReset.Text = "Reset";
+            this.checkboxReset.UseVisualStyleBackColor = true;
+            this.checkboxReset.CheckedChanged += new System.EventHandler(this.methodCheckbox_CheckedChanged);
             // 
-            // gameVersionLabel
+            // labelGameVersion
             // 
-            this.gameVersionLabel.Anchor = System.Windows.Forms.AnchorStyles.Right;
-            this.gameVersionLabel.AutoEllipsis = true;
-            this.gameVersionLabel.Location = new System.Drawing.Point(169, 5);
-            this.gameVersionLabel.Name = "gameVersionLabel";
-            this.gameVersionLabel.Size = new System.Drawing.Size(208, 13);
-            this.gameVersionLabel.TabIndex = 10;
-            this.gameVersionLabel.Text = "Game Version: 1.0";
-            this.gameVersionLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.labelGameVersion.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            this.labelGameVersion.AutoEllipsis = true;
+            this.labelGameVersion.Location = new System.Drawing.Point(169, 5);
+            this.labelGameVersion.Name = "labelGameVersion";
+            this.labelGameVersion.Size = new System.Drawing.Size(208, 13);
+            this.labelGameVersion.TabIndex = 10;
+            this.labelGameVersion.Text = "Game Version: 1.0";
+            this.labelGameVersion.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
-            // optionsLabel
+            // labelOptions
             // 
-            this.optionsLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.optionsLabel.AutoSize = true;
-            this.optionsLabel.Location = new System.Drawing.Point(3, 37);
-            this.optionsLabel.Name = "optionsLabel";
-            this.optionsLabel.Size = new System.Drawing.Size(70, 13);
-            this.optionsLabel.TabIndex = 9;
-            this.optionsLabel.Text = "Options:";
+            this.labelOptions.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.labelOptions.AutoSize = true;
+            this.labelOptions.Location = new System.Drawing.Point(3, 37);
+            this.labelOptions.Name = "labelOptions";
+            this.labelOptions.Size = new System.Drawing.Size(70, 13);
+            this.labelOptions.TabIndex = 9;
+            this.labelOptions.Text = "Options:";
             // 
-            // customSettingsLabel
+            // labelCustomSettings
             // 
-            this.customSettingsLabel.AutoSize = true;
-            this.customSettingsLabel.Location = new System.Drawing.Point(3, 63);
-            this.customSettingsLabel.Margin = new System.Windows.Forms.Padding(3, 5, 3, 0);
-            this.customSettingsLabel.Name = "customSettingsLabel";
-            this.customSettingsLabel.Size = new System.Drawing.Size(59, 13);
-            this.customSettingsLabel.TabIndex = 13;
-            this.customSettingsLabel.Text = "Advanced:";
+            this.labelCustomSettings.AutoSize = true;
+            this.labelCustomSettings.Location = new System.Drawing.Point(3, 63);
+            this.labelCustomSettings.Margin = new System.Windows.Forms.Padding(3, 5, 3, 0);
+            this.labelCustomSettings.Name = "labelCustomSettings";
+            this.labelCustomSettings.Size = new System.Drawing.Size(59, 13);
+            this.labelCustomSettings.TabIndex = 13;
+            this.labelCustomSettings.Text = "Advanced:";
+            // 
+            // treeContextMenu
+            // 
+            this.treeContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.cmiCheckBranch,
+            this.cmiUncheckBranch,
+            this.cmiResetBranchToDefault});
+            this.treeContextMenu.Name = "treeContextMenu";
+            this.treeContextMenu.Size = new System.Drawing.Size(189, 70);
+            // 
+            // cmiCheckBranch
+            // 
+            this.cmiCheckBranch.Name = "cmiCheckBranch";
+            this.cmiCheckBranch.Size = new System.Drawing.Size(188, 22);
+            this.cmiCheckBranch.Text = "Check Branch";
+            this.cmiCheckBranch.Click += new System.EventHandler(this.cmiCheckBranch_Click);
+            // 
+            // cmiUncheckBranch
+            // 
+            this.cmiUncheckBranch.Name = "cmiUncheckBranch";
+            this.cmiUncheckBranch.Size = new System.Drawing.Size(188, 22);
+            this.cmiUncheckBranch.Text = "Uncheck Branch";
+            this.cmiUncheckBranch.Click += new System.EventHandler(this.cmiUncheckBranch_Click);
+            // 
+            // cmiResetBranchToDefault
+            // 
+            this.cmiResetBranchToDefault.Name = "cmiResetBranchToDefault";
+            this.cmiResetBranchToDefault.Size = new System.Drawing.Size(188, 22);
+            this.cmiResetBranchToDefault.Text = "Reset Branch to default";
+            this.cmiResetBranchToDefault.Click += new System.EventHandler(this.cmiResetBranchToDefault_Click);
+            // 
+            // treeCustomSettings
+            // 
+            this.treeCustomSettings.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.treeCustomSettings.CheckBoxes = true;
+            this.tableLayoutPanel1.SetColumnSpan(this.treeCustomSettings, 2);
+            this.treeCustomSettings.Location = new System.Drawing.Point(79, 61);
+            this.treeCustomSettings.Name = "treeCustomSettings";
+            this.treeCustomSettings.Size = new System.Drawing.Size(380, 390);
+            this.treeCustomSettings.TabIndex = 14;
+            this.treeCustomSettings.AfterCheck += new System.Windows.Forms.TreeViewEventHandler(this.settingsTree_AfterCheck);
+            this.treeCustomSettings.NodeMouseClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.settingsTree_NodeMouseClick);
             // 
             // ComponentSettings
             // 
@@ -256,6 +292,7 @@
             this.flowLayoutPanel1.ResumeLayout(false);
             this.flowLayoutPanel1.PerformLayout();
             this.flowLayoutPanel2.ResumeLayout(false);
+            this.treeContextMenu.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -264,20 +301,24 @@
         #endregion
 
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
-        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label labelScriptPath;
         private System.Windows.Forms.Button btnSelectFile;
         public System.Windows.Forms.TextBox txtScriptPath;
-        private System.Windows.Forms.CheckedListBox customSettingsList;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
-        private System.Windows.Forms.Button checkAllButton;
-        private System.Windows.Forms.Button uncheckAllButton;
-        private System.Windows.Forms.Button resetToDefaultButton;
-        private System.Windows.Forms.Label optionsLabel;
-        private System.Windows.Forms.Label gameVersionLabel;
+        private System.Windows.Forms.Button btnCheckAll;
+        private System.Windows.Forms.Button btnUncheckAll;
+        private System.Windows.Forms.Button btnResetToDefault;
+        private System.Windows.Forms.Label labelOptions;
+        private System.Windows.Forms.Label labelGameVersion;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel2;
-        private System.Windows.Forms.CheckBox startCheckbox;
-        private System.Windows.Forms.CheckBox resetCheckbox;
-        private System.Windows.Forms.CheckBox splitCheckbox;
-        private System.Windows.Forms.Label customSettingsLabel;
+        private System.Windows.Forms.CheckBox checkboxStart;
+        private System.Windows.Forms.CheckBox checkboxReset;
+        private System.Windows.Forms.CheckBox checkboxSplit;
+        private System.Windows.Forms.Label labelCustomSettings;
+        private NewTreeView treeCustomSettings;
+        private System.Windows.Forms.ContextMenuStrip treeContextMenu;
+        private System.Windows.Forms.ToolStripMenuItem cmiCheckBranch;
+        private System.Windows.Forms.ToolStripMenuItem cmiUncheckBranch;
+        private System.Windows.Forms.ToolStripMenuItem cmiResetBranchToDefault;
     }
 }

--- a/ComponentSettings.Designer.cs
+++ b/ComponentSettings.Designer.cs
@@ -29,30 +29,90 @@
         private void InitializeComponent()
         {
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+            this.checkAllButton = new System.Windows.Forms.Button();
+            this.uncheckAllButton = new System.Windows.Forms.Button();
+            this.resetToDefaultButton = new System.Windows.Forms.Button();
             this.label1 = new System.Windows.Forms.Label();
             this.btnSelectFile = new System.Windows.Forms.Button();
             this.txtScriptPath = new System.Windows.Forms.TextBox();
+            this.aslSettings = new System.Windows.Forms.CheckedListBox();
+            this.optionsLabel = new System.Windows.Forms.Label();
+            this.gameVersion = new System.Windows.Forms.Label();
             this.tableLayoutPanel1.SuspendLayout();
+            this.flowLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
             // tableLayoutPanel1
             // 
+            this.tableLayoutPanel1.AutoSize = true;
             this.tableLayoutPanel1.ColumnCount = 3;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 76F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 81F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.btnSelectFile, 2, 0);
             this.tableLayoutPanel1.Controls.Add(this.txtScriptPath, 1, 0);
+            this.tableLayoutPanel1.Controls.Add(this.aslSettings, 1, 2);
+            this.tableLayoutPanel1.Controls.Add(this.optionsLabel, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 1, 3);
+            this.tableLayoutPanel1.Controls.Add(this.gameVersion, 1, 1);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(7, 7);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            this.tableLayoutPanel1.RowCount = 3;
+            this.tableLayoutPanel1.RowCount = 4;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(445, 227);
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(462, 523);
             this.tableLayoutPanel1.TabIndex = 0;
+            // 
+            // flowLayoutPanel1
+            // 
+            this.flowLayoutPanel1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.flowLayoutPanel1.AutoSize = true;
+            this.tableLayoutPanel1.SetColumnSpan(this.flowLayoutPanel1, 2);
+            this.flowLayoutPanel1.Controls.Add(this.checkAllButton);
+            this.flowLayoutPanel1.Controls.Add(this.uncheckAllButton);
+            this.flowLayoutPanel1.Controls.Add(this.resetToDefaultButton);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(206, 491);
+            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(253, 29);
+            this.flowLayoutPanel1.TabIndex = 8;
+            // 
+            // checkAllButton
+            // 
+            this.checkAllButton.Location = new System.Drawing.Point(3, 3);
+            this.checkAllButton.Name = "checkAllButton";
+            this.checkAllButton.Size = new System.Drawing.Size(62, 23);
+            this.checkAllButton.TabIndex = 5;
+            this.checkAllButton.Text = "Check all";
+            this.checkAllButton.UseVisualStyleBackColor = true;
+            this.checkAllButton.Click += new System.EventHandler(this.checkAllButton_Click);
+            // 
+            // uncheckAllButton
+            // 
+            this.uncheckAllButton.AutoSize = true;
+            this.uncheckAllButton.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.uncheckAllButton.Location = new System.Drawing.Point(71, 3);
+            this.uncheckAllButton.Name = "uncheckAllButton";
+            this.uncheckAllButton.Size = new System.Drawing.Size(74, 23);
+            this.uncheckAllButton.TabIndex = 6;
+            this.uncheckAllButton.Text = "Uncheck all";
+            this.uncheckAllButton.UseVisualStyleBackColor = true;
+            this.uncheckAllButton.Click += new System.EventHandler(this.uncheckAllButton_Click);
+            // 
+            // resetToDefaultButton
+            // 
+            this.resetToDefaultButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.resetToDefaultButton.Location = new System.Drawing.Point(151, 3);
+            this.resetToDefaultButton.Name = "resetToDefaultButton";
+            this.resetToDefaultButton.Size = new System.Drawing.Size(99, 23);
+            this.resetToDefaultButton.TabIndex = 7;
+            this.resetToDefaultButton.Text = "Reset to default";
+            this.resetToDefaultButton.UseVisualStyleBackColor = true;
+            this.resetToDefaultButton.Click += new System.EventHandler(this.resetToDefaultButton_Click);
             // 
             // label1
             // 
@@ -67,9 +127,9 @@
             // btnSelectFile
             // 
             this.btnSelectFile.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnSelectFile.Location = new System.Drawing.Point(367, 3);
+            this.btnSelectFile.Location = new System.Drawing.Point(385, 3);
             this.btnSelectFile.Name = "btnSelectFile";
-            this.btnSelectFile.Size = new System.Drawing.Size(75, 23);
+            this.btnSelectFile.Size = new System.Drawing.Size(74, 23);
             this.btnSelectFile.TabIndex = 1;
             this.btnSelectFile.Text = "Browse...";
             this.btnSelectFile.UseVisualStyleBackColor = true;
@@ -80,8 +140,41 @@
             this.txtScriptPath.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.txtScriptPath.Location = new System.Drawing.Point(79, 4);
             this.txtScriptPath.Name = "txtScriptPath";
-            this.txtScriptPath.Size = new System.Drawing.Size(282, 20);
+            this.txtScriptPath.Size = new System.Drawing.Size(300, 20);
             this.txtScriptPath.TabIndex = 0;
+            // 
+            // aslSettings
+            // 
+            this.aslSettings.CheckOnClick = true;
+            this.tableLayoutPanel1.SetColumnSpan(this.aslSettings, 2);
+            this.aslSettings.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.aslSettings.FormattingEnabled = true;
+            this.aslSettings.HorizontalScrollbar = true;
+            this.aslSettings.Location = new System.Drawing.Point(79, 61);
+            this.aslSettings.Name = "aslSettings";
+            this.aslSettings.Size = new System.Drawing.Size(380, 424);
+            this.aslSettings.TabIndex = 4;
+            this.aslSettings.ItemCheck += new System.Windows.Forms.ItemCheckEventHandler(this.aslSettings_ItemCheck);
+            // 
+            // optionsLabel
+            // 
+            this.optionsLabel.AutoSize = true;
+            this.optionsLabel.Location = new System.Drawing.Point(3, 58);
+            this.optionsLabel.Name = "optionsLabel";
+            this.optionsLabel.Padding = new System.Windows.Forms.Padding(0, 4, 0, 0);
+            this.optionsLabel.Size = new System.Drawing.Size(46, 17);
+            this.optionsLabel.TabIndex = 9;
+            this.optionsLabel.Text = "Options:";
+            // 
+            // gameVersion
+            // 
+            this.gameVersion.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.gameVersion.AutoSize = true;
+            this.gameVersion.Location = new System.Drawing.Point(79, 37);
+            this.gameVersion.Name = "gameVersion";
+            this.gameVersion.Size = new System.Drawing.Size(182, 13);
+            this.gameVersion.TabIndex = 10;
+            this.gameVersion.Text = "Detected Game Version: <unknown>";
             // 
             // ComponentSettings
             // 
@@ -90,10 +183,13 @@
             this.Controls.Add(this.tableLayoutPanel1);
             this.Name = "ComponentSettings";
             this.Padding = new System.Windows.Forms.Padding(7);
-            this.Size = new System.Drawing.Size(459, 241);
+            this.Size = new System.Drawing.Size(476, 537);
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
+            this.flowLayoutPanel1.ResumeLayout(false);
+            this.flowLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
@@ -103,6 +199,12 @@
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Button btnSelectFile;
         public System.Windows.Forms.TextBox txtScriptPath;
-
+        private System.Windows.Forms.CheckedListBox aslSettings;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
+        private System.Windows.Forms.Button checkAllButton;
+        private System.Windows.Forms.Button uncheckAllButton;
+        private System.Windows.Forms.Button resetToDefaultButton;
+        private System.Windows.Forms.Label optionsLabel;
+        private System.Windows.Forms.Label gameVersion;
     }
 }

--- a/ComponentSettings.Designer.cs
+++ b/ComponentSettings.Designer.cs
@@ -29,18 +29,24 @@
         private void InitializeComponent()
         {
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.label1 = new System.Windows.Forms.Label();
+            this.btnSelectFile = new System.Windows.Forms.Button();
+            this.txtScriptPath = new System.Windows.Forms.TextBox();
+            this.customSettingsList = new System.Windows.Forms.CheckedListBox();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.checkAllButton = new System.Windows.Forms.Button();
             this.uncheckAllButton = new System.Windows.Forms.Button();
             this.resetToDefaultButton = new System.Windows.Forms.Button();
-            this.label1 = new System.Windows.Forms.Label();
-            this.btnSelectFile = new System.Windows.Forms.Button();
-            this.txtScriptPath = new System.Windows.Forms.TextBox();
-            this.aslSettings = new System.Windows.Forms.CheckedListBox();
-            this.optionsLabel = new System.Windows.Forms.Label();
+            this.flowLayoutPanel2 = new System.Windows.Forms.FlowLayoutPanel();
+            this.startCheckbox = new System.Windows.Forms.CheckBox();
+            this.splitCheckbox = new System.Windows.Forms.CheckBox();
+            this.resetCheckbox = new System.Windows.Forms.CheckBox();
             this.gameVersion = new System.Windows.Forms.Label();
+            this.optionsLabel = new System.Windows.Forms.Label();
+            this.customSettingsLabel = new System.Windows.Forms.Label();
             this.tableLayoutPanel1.SuspendLayout();
             this.flowLayoutPanel1.SuspendLayout();
+            this.flowLayoutPanel2.SuspendLayout();
             this.SuspendLayout();
             // 
             // tableLayoutPanel1
@@ -53,20 +59,65 @@
             this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.btnSelectFile, 2, 0);
             this.tableLayoutPanel1.Controls.Add(this.txtScriptPath, 1, 0);
-            this.tableLayoutPanel1.Controls.Add(this.aslSettings, 1, 2);
-            this.tableLayoutPanel1.Controls.Add(this.optionsLabel, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.customSettingsList, 1, 2);
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 1, 3);
-            this.tableLayoutPanel1.Controls.Add(this.gameVersion, 1, 1);
+            this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel2, 1, 1);
+            this.tableLayoutPanel1.Controls.Add(this.optionsLabel, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.customSettingsLabel, 0, 2);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(7, 7);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 4;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tableLayoutPanel1.Size = new System.Drawing.Size(462, 523);
             this.tableLayoutPanel1.TabIndex = 0;
+            // 
+            // label1
+            // 
+            this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(3, 8);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(70, 13);
+            this.label1.TabIndex = 3;
+            this.label1.Text = "Script Path:";
+            // 
+            // btnSelectFile
+            // 
+            this.btnSelectFile.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnSelectFile.Location = new System.Drawing.Point(385, 3);
+            this.btnSelectFile.Name = "btnSelectFile";
+            this.btnSelectFile.Size = new System.Drawing.Size(74, 23);
+            this.btnSelectFile.TabIndex = 1;
+            this.btnSelectFile.Text = "Browse...";
+            this.btnSelectFile.UseVisualStyleBackColor = true;
+            this.btnSelectFile.Click += new System.EventHandler(this.btnSelectFile_Click);
+            // 
+            // txtScriptPath
+            // 
+            this.txtScriptPath.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtScriptPath.Location = new System.Drawing.Point(79, 4);
+            this.txtScriptPath.Name = "txtScriptPath";
+            this.txtScriptPath.Size = new System.Drawing.Size(300, 20);
+            this.txtScriptPath.TabIndex = 0;
+            // 
+            // customSettingsList
+            // 
+            this.customSettingsList.CheckOnClick = true;
+            this.tableLayoutPanel1.SetColumnSpan(this.customSettingsList, 2);
+            this.customSettingsList.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.customSettingsList.FormattingEnabled = true;
+            this.customSettingsList.HorizontalScrollbar = true;
+            this.customSettingsList.IntegralHeight = false;
+            this.customSettingsList.Location = new System.Drawing.Point(79, 61);
+            this.customSettingsList.Name = "customSettingsList";
+            this.customSettingsList.Size = new System.Drawing.Size(380, 424);
+            this.customSettingsList.TabIndex = 4;
+            this.customSettingsList.ItemCheck += new System.Windows.Forms.ItemCheckEventHandler(this.customSettingsList_ItemCheck);
             // 
             // flowLayoutPanel1
             // 
@@ -114,67 +165,85 @@
             this.resetToDefaultButton.UseVisualStyleBackColor = true;
             this.resetToDefaultButton.Click += new System.EventHandler(this.resetToDefaultButton_Click);
             // 
-            // label1
+            // flowLayoutPanel2
             // 
-            this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(3, 8);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(70, 13);
-            this.label1.TabIndex = 3;
-            this.label1.Text = "Script Path:";
+            this.flowLayoutPanel2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.flowLayoutPanel2.AutoSize = true;
+            this.tableLayoutPanel1.SetColumnSpan(this.flowLayoutPanel2, 2);
+            this.flowLayoutPanel2.Controls.Add(this.startCheckbox);
+            this.flowLayoutPanel2.Controls.Add(this.splitCheckbox);
+            this.flowLayoutPanel2.Controls.Add(this.resetCheckbox);
+            this.flowLayoutPanel2.Controls.Add(this.gameVersion);
+            this.flowLayoutPanel2.Location = new System.Drawing.Point(79, 32);
+            this.flowLayoutPanel2.Name = "flowLayoutPanel2";
+            this.flowLayoutPanel2.Size = new System.Drawing.Size(380, 23);
+            this.flowLayoutPanel2.TabIndex = 12;
             // 
-            // btnSelectFile
+            // startCheckbox
             // 
-            this.btnSelectFile.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnSelectFile.Location = new System.Drawing.Point(385, 3);
-            this.btnSelectFile.Name = "btnSelectFile";
-            this.btnSelectFile.Size = new System.Drawing.Size(74, 23);
-            this.btnSelectFile.TabIndex = 1;
-            this.btnSelectFile.Text = "Browse...";
-            this.btnSelectFile.UseVisualStyleBackColor = true;
-            this.btnSelectFile.Click += new System.EventHandler(this.btnSelectFile_Click);
+            this.startCheckbox.Checked = true;
+            this.startCheckbox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.startCheckbox.Location = new System.Drawing.Point(3, 3);
+            this.startCheckbox.Name = "startCheckbox";
+            this.startCheckbox.Size = new System.Drawing.Size(48, 17);
+            this.startCheckbox.TabIndex = 11;
+            this.startCheckbox.Text = "Start";
+            this.startCheckbox.UseVisualStyleBackColor = true;
+            this.startCheckbox.CheckedChanged += new System.EventHandler(this.methodCheckbox_CheckedChanged);
             // 
-            // txtScriptPath
+            // splitCheckbox
             // 
-            this.txtScriptPath.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtScriptPath.Location = new System.Drawing.Point(79, 4);
-            this.txtScriptPath.Name = "txtScriptPath";
-            this.txtScriptPath.Size = new System.Drawing.Size(300, 20);
-            this.txtScriptPath.TabIndex = 0;
+            this.splitCheckbox.Checked = true;
+            this.splitCheckbox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.splitCheckbox.Location = new System.Drawing.Point(57, 3);
+            this.splitCheckbox.Name = "splitCheckbox";
+            this.splitCheckbox.Size = new System.Drawing.Size(46, 17);
+            this.splitCheckbox.TabIndex = 0;
+            this.splitCheckbox.Text = "Split";
+            this.splitCheckbox.UseVisualStyleBackColor = true;
+            this.splitCheckbox.CheckedChanged += new System.EventHandler(this.methodCheckbox_CheckedChanged);
             // 
-            // aslSettings
+            // resetCheckbox
             // 
-            this.aslSettings.CheckOnClick = true;
-            this.tableLayoutPanel1.SetColumnSpan(this.aslSettings, 2);
-            this.aslSettings.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.aslSettings.FormattingEnabled = true;
-            this.aslSettings.HorizontalScrollbar = true;
-            this.aslSettings.Location = new System.Drawing.Point(79, 61);
-            this.aslSettings.Name = "aslSettings";
-            this.aslSettings.Size = new System.Drawing.Size(380, 424);
-            this.aslSettings.TabIndex = 4;
-            this.aslSettings.ItemCheck += new System.Windows.Forms.ItemCheckEventHandler(this.aslSettings_ItemCheck);
-            // 
-            // optionsLabel
-            // 
-            this.optionsLabel.AutoSize = true;
-            this.optionsLabel.Location = new System.Drawing.Point(3, 58);
-            this.optionsLabel.Name = "optionsLabel";
-            this.optionsLabel.Padding = new System.Windows.Forms.Padding(0, 4, 0, 0);
-            this.optionsLabel.Size = new System.Drawing.Size(46, 17);
-            this.optionsLabel.TabIndex = 9;
-            this.optionsLabel.Text = "Options:";
+            this.resetCheckbox.Checked = true;
+            this.resetCheckbox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.resetCheckbox.Location = new System.Drawing.Point(109, 3);
+            this.resetCheckbox.Name = "resetCheckbox";
+            this.resetCheckbox.Size = new System.Drawing.Size(54, 17);
+            this.resetCheckbox.TabIndex = 0;
+            this.resetCheckbox.Text = "Reset";
+            this.resetCheckbox.UseVisualStyleBackColor = true;
+            this.resetCheckbox.CheckedChanged += new System.EventHandler(this.methodCheckbox_CheckedChanged);
             // 
             // gameVersion
             // 
-            this.gameVersion.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.gameVersion.AutoSize = true;
-            this.gameVersion.Location = new System.Drawing.Point(79, 37);
+            this.gameVersion.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            this.gameVersion.Location = new System.Drawing.Point(169, 5);
             this.gameVersion.Name = "gameVersion";
-            this.gameVersion.Size = new System.Drawing.Size(182, 13);
+            this.gameVersion.Size = new System.Drawing.Size(208, 13);
             this.gameVersion.TabIndex = 10;
-            this.gameVersion.Text = "Detected Game Version: <unknown>";
+            this.gameVersion.Text = "Game Version: 1.0";
+            this.gameVersion.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // optionsLabel
+            // 
+            this.optionsLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.optionsLabel.AutoSize = true;
+            this.optionsLabel.Location = new System.Drawing.Point(3, 37);
+            this.optionsLabel.Name = "optionsLabel";
+            this.optionsLabel.Size = new System.Drawing.Size(70, 13);
+            this.optionsLabel.TabIndex = 9;
+            this.optionsLabel.Text = "Options:";
+            // 
+            // customSettingsLabel
+            // 
+            this.customSettingsLabel.AutoSize = true;
+            this.customSettingsLabel.Location = new System.Drawing.Point(3, 63);
+            this.customSettingsLabel.Margin = new System.Windows.Forms.Padding(3, 5, 3, 0);
+            this.customSettingsLabel.Name = "customSettingsLabel";
+            this.customSettingsLabel.Size = new System.Drawing.Size(59, 13);
+            this.customSettingsLabel.TabIndex = 13;
+            this.customSettingsLabel.Text = "Advanced:";
             // 
             // ComponentSettings
             // 
@@ -188,6 +257,7 @@
             this.tableLayoutPanel1.PerformLayout();
             this.flowLayoutPanel1.ResumeLayout(false);
             this.flowLayoutPanel1.PerformLayout();
+            this.flowLayoutPanel2.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -199,12 +269,17 @@
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Button btnSelectFile;
         public System.Windows.Forms.TextBox txtScriptPath;
-        private System.Windows.Forms.CheckedListBox aslSettings;
+        private System.Windows.Forms.CheckedListBox customSettingsList;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
         private System.Windows.Forms.Button checkAllButton;
         private System.Windows.Forms.Button uncheckAllButton;
         private System.Windows.Forms.Button resetToDefaultButton;
         private System.Windows.Forms.Label optionsLabel;
         private System.Windows.Forms.Label gameVersion;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel2;
+        private System.Windows.Forms.CheckBox startCheckbox;
+        private System.Windows.Forms.CheckBox resetCheckbox;
+        private System.Windows.Forms.CheckBox splitCheckbox;
+        private System.Windows.Forms.Label customSettingsLabel;
     }
 }

--- a/ComponentSettings.cs
+++ b/ComponentSettings.cs
@@ -195,7 +195,11 @@ namespace LiveSplit.UI.Components
                     ASL.ASLSetting setting = settings.BasicSettings[name];
                     checkbox.Enabled = true;
                     checkbox.Tag = setting;
-                    bool value = _basicSettingsFromXml[name];
+                    bool value = true;
+                    if (_basicSettingsFromXml.ContainsKey(name))
+                    {
+                        value = _basicSettingsFromXml[name];
+                    }
                     checkbox.Checked = value;
                     setting.Value = value;
                 }
@@ -303,7 +307,6 @@ namespace LiveSplit.UI.Components
             if (setting != null)
             {
                 setting.Value = checkbox.Checked;
-                Console.WriteLine("changed"+setting.Value);
             }
         }
 
@@ -312,7 +315,6 @@ namespace LiveSplit.UI.Components
             // Update value in the ASLSetting object, which also changes it in the ASL script
             ASL.ASLSetting setting = (ASL.ASLSetting)e.Node.Tag;
             setting.Value = e.Node.Checked;
-            Console.WriteLine("Checked: "+setting+" "+setting.Value);
 
             // Only change color of childnodes if this node isn't already grayed out
             if (e.Node.ForeColor != SystemColors.GrayText) 

--- a/ComponentSettings.cs
+++ b/ComponentSettings.cs
@@ -12,14 +12,14 @@ namespace LiveSplit.UI.Components
 
         private Dictionary<string, bool> _lastLoadedFromSettings;
         private Dictionary<string, bool> _defaultValues;
-        private Dictionary<object, ASL.ASLSetting> _methodSettings;
+        private Dictionary<object, ASL.ASLSetting> _basicSettings;
 
         public ComponentSettings()
         {
             InitializeComponent();
 
             ScriptPath = "";
-            _methodSettings = new Dictionary<object, ASL.ASLSetting>();
+            _basicSettings = new Dictionary<object, ASL.ASLSetting>();
 
             txtScriptPath.DataBindings.Add("Text", this, "ScriptPath", false, DataSourceUpdateMode.OnPropertyChanged);
         }
@@ -49,7 +49,6 @@ namespace LiveSplit.UI.Components
                 splitCheckbox.Checked = SettingsHelper.ParseBool(element["Split"], true);
                 parseCustomSettingsFromXml(element);
             }
-            Console.WriteLine("SetSettings #####"+element["Start"]);
         }
 
         // Sets the custom settings defined in the ASL script. Populates the CheckedListBox.
@@ -67,28 +66,27 @@ namespace LiveSplit.UI.Components
             updateItemsInList(_lastLoadedFromSettings);
             updateCustomSettingsVisibility();
 
-            updateBasicSettings(settings);
+            initBasicSettings(settings);
         }
 
-        private void updateBasicSettings(ASL.ASLSettings settings)
+        private void initBasicSettings(ASL.ASLSettings settings)
         {
-            _methodSettings.Clear();
-            updateBasicSetting(settings, startCheckbox, "start");
-            updateBasicSetting(settings, resetCheckbox, "reset");
-            updateBasicSetting(settings, splitCheckbox, "split");
+            _basicSettings.Clear();
+            initBasicSetting(settings, startCheckbox, "start");
+            initBasicSetting(settings, resetCheckbox, "reset");
+            initBasicSetting(settings, splitCheckbox, "split");
         }
 
-        private void updateBasicSetting(ASL.ASLSettings settings, CheckBox checkbox, string name)
+        private void initBasicSetting(ASL.ASLSettings settings, CheckBox checkbox, string name)
         {
-            //checkbox.DataBindings.Clear();
             if (settings.MethodPresent(name))
             {
                 ASL.ASLSetting setting = settings.MethodSettings[name];
-                //checkbox.DataBindings.Add("Checked", setting, "Value");
-                _methodSettings.Add(checkbox, setting);
+                _basicSettings.Add(checkbox, setting);
                 checkbox.Enabled = true;
                 setting.Value = checkbox.Checked;
-            } else
+            }
+            else
             {
                 checkbox.Enabled = false;
                 checkbox.Checked = false;
@@ -215,9 +213,9 @@ namespace LiveSplit.UI.Components
 
         private void methodCheckbox_CheckedChanged(object sender, EventArgs e)
         {
-            if (_methodSettings.ContainsKey(sender))
+            if (_basicSettings.ContainsKey(sender))
             {
-                _methodSettings[sender].Value = ((CheckBox)sender).Checked;
+                _basicSettings[sender].Value = ((CheckBox)sender).Checked;
             }
         }
 

--- a/ComponentSettings.cs
+++ b/ComponentSettings.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Windows.Forms;
 using System.Xml;
 
@@ -7,6 +9,9 @@ namespace LiveSplit.UI.Components
     public partial class ComponentSettings : UserControl
     {
         public string ScriptPath { get; set; }
+
+        private Dictionary<string, bool> _lastLoadedFromSettings;
+        private Dictionary<string, bool> _defaultValues;
 
         public ComponentSettings()
         {
@@ -17,20 +22,130 @@ namespace LiveSplit.UI.Components
             txtScriptPath.DataBindings.Add("Text", this, "ScriptPath", false, DataSourceUpdateMode.OnPropertyChanged);
         }
 
+        public void SetGameVersion(string version)
+        {
+            gameVersion.Text = version != null ? "Detected Game Version: " + version : "";
+        }
+
         public XmlNode GetSettings(XmlDocument document)
         {
             var settingsNode = document.CreateElement("Settings");
             settingsNode.AppendChild(SettingsHelper.ToElement(document, "Version", "1.4"));
             settingsNode.AppendChild(SettingsHelper.ToElement(document, "ScriptPath", ScriptPath));
+            appendASLSettingsToXml(document, settingsNode);
             return settingsNode;
         }
 
+        /// <summary>
+        /// Loads the settings of this component from Xml. This might happen more than once
+        /// (e.g. when the settings dialog is cancelled to restore previous settings).
+        /// </summary>
+        /// <param name="settings"></param>
         public void SetSettings(XmlNode settings)
         {
             var element = (XmlElement)settings;
             if (!element.IsEmpty)
             {
                 ScriptPath = SettingsHelper.ParseString(element["ScriptPath"], string.Empty);
+                parseASLSettingsFromXml(element);
+            }
+            Console.WriteLine("SetSEttings");
+        }
+
+        /// <summary>
+        /// Sets the custom settings defined in the ASL script. Populates the CheckedListBox.
+        /// </summary>
+        /// <param name="settings"></param>
+        public void SetASLSettings(ASL.ASLSettings settings)
+        {
+            aslSettings.Items.Clear();
+            Dictionary<string, bool> values = new Dictionary<string, bool>();
+            foreach (var item in settings.Settings)
+            {
+                ASL.ASLSetting setting = item.Value;
+                aslSettings.Items.Add(setting, setting.Enabled);
+                values.Add(setting.Name, setting.Enabled);
+            }
+            _defaultValues = values;
+            // Update from settings (in case settings are already loaded, which should be the case)
+            updateItemsInList(_lastLoadedFromSettings);
+            updateOptionsVisibility();
+        }
+
+        private void updateOptionsVisibility()
+        {
+            bool show = _defaultValues.Count > 0;
+            aslSettings.Visible = show;
+            resetToDefaultButton.Visible = show;
+            checkAllButton.Visible = show;
+            uncheckAllButton.Visible = show;
+            optionsLabel.Visible = show;
+        }
+
+        private void appendASLSettingsToXml(XmlDocument document, XmlNode parent)
+        {
+            XmlElement aslParent = document.CreateElement("ASLSettings");
+            foreach (var item in aslSettings.Items)
+            {
+                var setting = (ASL.ASLSetting)item;
+                XmlElement element = SettingsHelper.ToElement(document, "Setting", setting.Enabled);
+                XmlAttribute id = SettingsHelper.ToAttribute(document, "id", setting.Name);
+                element.Attributes.Append(id);
+                aslParent.AppendChild(element);
+            }
+            parent.AppendChild(aslParent);
+        }
+
+        /// <summary>
+        /// Parses the ASLSettings from the given XML Element (which should be the Settings-element
+        /// from the component settings). Stores them in a Dictionary for later usage.
+        /// </summary>
+        /// <param name="data"></param>
+        private void parseASLSettingsFromXml(XmlElement data)
+        {
+            Dictionary<string, bool> result = new Dictionary<string, bool>();
+            XmlElement aslSettingsNode = data["ASLSettings"];
+            if (aslSettingsNode != null && aslSettingsNode.HasChildNodes)
+            {
+                foreach (XmlElement element in aslSettingsNode.ChildNodes)
+                {
+                    if (element.Name == "Setting")
+                    {
+                        string id = element.Attributes["id"].Value;
+                        bool value = SettingsHelper.ParseBool(element);
+                        if (id != null)
+                        {
+                            result.Add(id, value);
+                        }
+                    }
+                }
+            }
+            _lastLoadedFromSettings = result;
+            // Update from settings when loaded (in case the list is already populated)
+            updateItemsInList(_lastLoadedFromSettings);
+        }
+
+        /// <summary>
+        /// Updates the values of the CheckedListBox entries based on what was last loaded from
+        /// the settings. This will implicitly also update the value in the ASLSetting
+        /// object in the list.
+        /// </summary>
+        private void updateItemsInList(Dictionary<string, bool> settingValues)
+        {
+            if (settingValues == null)
+            {
+                return;
+            }
+            for (int i = 0; i < aslSettings.Items.Count; i++)
+            {
+                var setting = (ASL.ASLSetting)aslSettings.Items[i];
+                string id = setting.Name;
+                bool value = setting.Enabled;
+                if (settingValues.ContainsKey(id))
+                {
+                    value = settingValues[id];
+                }
+                aslSettings.SetItemChecked(i, value);
             }
         }
 
@@ -44,6 +159,42 @@ namespace LiveSplit.UI.Components
             var result = dialog.ShowDialog();
             if (result == DialogResult.OK)
                 ScriptPath = txtScriptPath.Text = dialog.FileName;
+        }
+
+        private void aslSettings_ItemCheck(object sender, ItemCheckEventArgs e)
+        {
+            ASL.ASLSetting setting = (ASL.ASLSetting)aslSettings.Items[e.Index];
+            setting.Enabled = e.NewValue == CheckState.Checked;
+            Console.WriteLine(((CheckedListBox)sender).Items[e.Index] + " " + e.NewValue);
+            
+
+            //ASL.ASLSetting selected = (ASL.ASLSetting)aslSettings.SelectedItem;
+            //if (selected != null)
+            //{
+            //    selected.Enabled = e.NewValue == CheckState.Checked;
+            //    Console.WriteLine(((CheckedListBox)sender).Items[e.Index] + " " + e.NewValue);
+            //}
+        }
+
+        private void checkAllButton_Click(object sender, EventArgs e)
+        {
+            for (int i = 0; i < aslSettings.Items.Count; i++)
+            {
+                aslSettings.SetItemChecked(i, true);
+            }
+        }
+
+        private void uncheckAllButton_Click(object sender, EventArgs e)
+        {
+            for (int i = 0; i < aslSettings.Items.Count; i++)
+            {
+                aslSettings.SetItemChecked(i, false);
+            }
+        }
+
+        private void resetToDefaultButton_Click(object sender, EventArgs e)
+        {
+            updateItemsInList(_defaultValues);
         }
     }
 }

--- a/ComponentSettings.cs
+++ b/ComponentSettings.cs
@@ -36,11 +36,8 @@ namespace LiveSplit.UI.Components
             return settingsNode;
         }
 
-        /// <summary>
-        /// Loads the settings of this component from Xml. This might happen more than once
-        /// (e.g. when the settings dialog is cancelled to restore previous settings).
-        /// </summary>
-        /// <param name="settings"></param>
+        // Loads the settings of this component from Xml. This might happen more than once
+        // (e.g. when the settings dialog is cancelled to restore previous settings).
         public void SetSettings(XmlNode settings)
         {
             var element = (XmlElement)settings;
@@ -55,10 +52,7 @@ namespace LiveSplit.UI.Components
             Console.WriteLine("SetSettings #####"+element["Start"]);
         }
 
-        /// <summary>
-        /// Sets the custom settings defined in the ASL script. Populates the CheckedListBox.
-        /// </summary>
-        /// <param name="settings"></param>
+        // Sets the custom settings defined in the ASL script. Populates the CheckedListBox.
         public void SetASLSettings(ASL.ASLSettings settings)
         {
             customSettingsList.Items.Clear();
@@ -111,11 +105,9 @@ namespace LiveSplit.UI.Components
             customSettingsLabel.Visible = show;
         }
 
-        /// <summary>
-        /// Updates the values of the CheckedListBox entries based on what was last loaded from
-        /// the settings. This will implicitly also update the value in the ASLSetting
-        /// object in the list.
-        /// </summary>
+        // Updates the values of the CheckedListBox entries based on what was last loaded from
+        // the settings. This will implicitly also update the value in the ASLSetting
+        // object in the list.
         private void updateItemsInList(Dictionary<string, bool> settingValues)
         {
             if (settingValues == null)
@@ -149,11 +141,8 @@ namespace LiveSplit.UI.Components
             parent.AppendChild(aslParent);
         }
 
-        /// <summary>
-        /// Parses the ASLSettings from the given XML Element (which should be the Settings-element
-        /// from the component settings). Stores them in a Dictionary for later usage.
-        /// </summary>
-        /// <param name="data"></param>
+        // Parses the ASLSettings from the given XML Element (which should be the Settings-element
+        // from the component settings). Stores them in a Dictionary for later usage.
         private void parseCustomSettingsFromXml(XmlElement data)
         {
             Dictionary<string, bool> result = new Dictionary<string, bool>();
@@ -198,6 +187,7 @@ namespace LiveSplit.UI.Components
         private void customSettingsList_ItemCheck(object sender, ItemCheckEventArgs e)
         {
             ASL.ASLSetting setting = (ASL.ASLSetting)customSettingsList.Items[e.Index];
+            // Update value in the ASLSetting object, which also changes it in the ASL script
             setting.Value = e.NewValue == CheckState.Checked;
             //Console.WriteLine(((CheckedListBox)sender).Items[e.Index] + " " + e.NewValue);
         }

--- a/ComponentSettings.cs
+++ b/ComponentSettings.cs
@@ -103,9 +103,10 @@ namespace LiveSplit.UI.Components
             customSettingsLabel.Visible = show;
         }
 
-        // Updates the values of the CheckedListBox entries based on what was last loaded from
-        // the settings. This will implicitly also update the value in the ASLSetting
-        // object in the list.
+        // Updates the checked state of the CheckedListBox items based on the
+        // settingValues parameter. This will implicitly also update the value
+        // in the associated ASLSetting objects, which are shared with the ASL
+        // script.
         private void updateItemsInList(Dictionary<string, bool> settingValues)
         {
             if (settingValues == null)
@@ -167,7 +168,7 @@ namespace LiveSplit.UI.Components
 
         public void SetGameVersion(string version)
         {
-            gameVersion.Text = version != null ? "Game Version: " + version : "";
+            gameVersionLabel.Text = version != null ? "Game Version: " + version : "";
         }
 
         private void btnSelectFile_Click(object sender, EventArgs e)
@@ -187,7 +188,6 @@ namespace LiveSplit.UI.Components
             ASL.ASLSetting setting = (ASL.ASLSetting)customSettingsList.Items[e.Index];
             // Update value in the ASLSetting object, which also changes it in the ASL script
             setting.Value = e.NewValue == CheckState.Checked;
-            //Console.WriteLine(((CheckedListBox)sender).Items[e.Index] + " " + e.NewValue);
         }
 
         private void checkAllButton_Click(object sender, EventArgs e)

--- a/ComponentSettings.resx
+++ b/ComponentSettings.resx
@@ -117,4 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="treeContextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/LiveSplit.ScriptableAutoSplit.csproj
+++ b/LiveSplit.ScriptableAutoSplit.csproj
@@ -58,8 +58,10 @@
     <Compile Include="ASL\ASLMethod.cs" />
     <Compile Include="ASL\ASLParser.cs" />
     <Compile Include="ASL\ASLScript.cs" />
+    <Compile Include="ASL\ASLSettings.cs" />
     <Compile Include="ASL\ASLState.cs" />
     <Compile Include="ASL\ASLValueDefinition.cs" />
+    <Compile Include="ASL\ASLSetting.cs" />
     <Compile Include="Component.cs" />
     <Compile Include="ComponentSettings.cs">
       <SubType>UserControl</SubType>


### PR DESCRIPTION
This adds additional GUI settings to ASL scripts:

* Add checkboxes for `start`, `reset`, `split`, which if disabled cause the return value of the associated methods to be ignored.
  * The methods are still run either way, because the script may perform some actions in them relevant for the other methods. Just the return value is not acted upon.
  * For methods that are not defined or empty, the checkbox is disabled (greyed out).
* Add a list of custom boolean settings that can be defined in the ASL script:
  * In the new `startup` method settings can be added via `AddSetting(settingId, defaultValue, descriptionShownInTheGui)`. The `startup` method is run once when the script first loads (but not yet connected to a game).
  * In all other methods (except `shutdown`) `Enabled(settingId)` can be used to return the current value of that setting.
  * The settings are added to the list in the same order as they are defined in the ASL script.
  * The list of settings is only visible in the GUI if the script actually defined custom settings.

There are also a few other tweaks:

* Add a generic `shutdown` method which runs when the script is disposed of (either when a new script is created or when the ASL Component is disposed).
* Select the state descriptor without a version by default, instead of just the first state descriptor in the file. If there is none without a version, then it still selects the first one as default.
* Add a label to the GUI that displays what `version` is set to. This can be useful as a feedback to the user of the script if e.g. the script only supports some features for some game versions. If `version` is not set, the label is not visible.
* Put initialization (that is executed after connecting to a game) into it's own method and runs it more than once if an error occured.
  * This is mainly in response to the error mentioned in issue LiveSplit/LiveSplit#482 (Only part of a ReadProcessMemory or WriteProcessMemory request was completed), but could also be useful for other errors that may only appear shortly after connecting to the game. Either way, running the rest of the script if initialization already failed is probably not a good idea. Especially since the ASL script may do some important stuff in `init` that the rest of the script relies on.
* Always set `version` to whatever it is set to in `init`, even if no state descriptor matching that version is defined. Not setting `version` even though the script author explicitly sets it seemed unexpected.
* If the `update` method explicitly returns `false` no other methods (like `start`, `split`, ..) are run. This can be useful if no actions should be performed in some game states or as a simple way to disable the script if the game version is not supported altogether.
* Add some default debug messages that can be viewed by ASL script authors in DebugView to help in development.

These changes have also been discussed in issue LiveSplit/LiveSplit#373.

GUI Preview:
![asl_settings](https://cloud.githubusercontent.com/assets/5621113/12945494/04601266-cfee-11e5-873a-8a87bfe0f3c1.jpg)
