### PR TITLE
Fix when Custom Settings state is updated

### DIFF
--- a/ComponentSettings.cs
+++ b/ComponentSettings.cs
@@ -219,11 +219,10 @@ namespace LiveSplit.UI.Components
                         result.Add(id, value);
                     }
                 }
-            }
-
-            _custom_settings_state = result;
-            // Update tree with loaded state (in case the tree is already populated)
-            UpdateNodeCheckedState(_custom_settings_state);
+                _custom_settings_state = result;
+                // Update tree with loaded state (in case the tree is already populated)
+                UpdateNodeCheckedState(_custom_settings_state);
+            } 
         }
 
         private void InitBasicSettings(ASLSettings settings)


### PR DESCRIPTION
If a new XML node is provided, don't update the custom settings state if
the node contains no custom settings. This fixes the issue of pressing
cancel when a script is broken causing your settings to be overriden with
the default ones.