### PR TITLE
Settings fix

### DIFF
--- a/Component.cs
+++ b/Component.cs
@@ -152,7 +152,7 @@ namespace LiveSplit.UI.Components
             try
             {
                 ASLSettings settings = Script.RunStartup(_state);
-                _settings.SetASLSettings(settings);
+                _settings.SetASLSettings(settings, true);
             }
             catch (Exception ex)
             {
@@ -179,7 +179,7 @@ namespace LiveSplit.UI.Components
             {
                 Script.Dispose();
                 _settings.SetGameVersion(null);
-                _settings.SetASLSettings(new ASLSettings());
+                _settings.SetASLSettings(new ASLSettings(), false);
 
                 // Script should no longer be used, even in case of error
                 // (which the ASL shutdown method may contain)


### PR DESCRIPTION
This is mostly for script developers, I don't think it really affects regular users who would just activate the script in the Splits Editor.

This should keep the state more reliably. It now uses the state dicts to not only keep the state between reloads, but also return it on `GetSettings()`, so even if the script is broken or unloaded, it returns the last state (unless you explicitly changed the `Script Path` to empty). The state only gets synchronized with the custom settings loaded from the ASL when the script is actually loaded (not when `SetASLSettings()` is called for script cleanup).

This should fix the issue with using `Cancel` to get out of the dialog while the script is broken and losing the current state. Also fixes the same issues with the basic settings (start/split/reset) and some minor inconsistencies also having to do with using `Cancel` to get out of the dialog.

This of course has the issue that settings can be carried over when you change to a completely different script, but trying to e.g. show a prompt to ask the user if he wants to carry over the settings didn't seem very easy to implement consistently because of possibly changing the script several times and again `Cancel`ling out of the dialog making it more complicated. This was also an issue before, but at least the behaviour is more consistent now. Since this doesn't store settings for different scripts (using different Layouts per script or using scripts out of the Splits Editor and saving it with the Splits is the intended way here I would say) this shouldn't come too surprising and should be good enough for now.

Feel free to thoroughly test this, because it seems like this is sometimes a bit more complicated and confusing than it might seem and there could still be bugs.