### PR TITLE
Fix setting initialization, add explicit default value attribute

### DIFF
--- a/ASL/ASLSettings.cs
+++ b/ASL/ASLSettings.cs
@@ -10,6 +10,7 @@ namespace LiveSplit.ASL
         public string Id { get; }
         public string Label { get; }
         public bool Value { get; set; }
+        public bool DefaultValue { get; }
         public string Parent { get; }
         public string ToolTip { get; set; }
 
@@ -17,6 +18,7 @@ namespace LiveSplit.ASL
         {
             Id = id;
             Value = default_value;
+            DefaultValue = default_value;
             Label = label;
             Parent = parent;
         }

--- a/ComponentSettings.cs
+++ b/ComponentSettings.cs
@@ -125,6 +125,7 @@ namespace LiveSplit.UI.Components
                     ContextMenuStrip = this.treeContextMenu2,
                     ToolTipText = setting.ToolTip
                 };
+                setting.Value = value;
 
                 if (setting.Parent == null)
                 {
@@ -137,7 +138,7 @@ namespace LiveSplit.UI.Components
                 }
 
                 flat.Add(setting.Id, node);
-                _default_values.Add(setting.Id, setting.Value);
+                _default_values.Add(setting.Id, setting.DefaultValue);
                 values.Add(setting.Id, value);
             }
 


### PR DESCRIPTION
The latest changes introduced this bug where the actual `ASLSetting` object wouldn't be correctly initialized anymore. Hopefully this fixes it. Also added a `DefaultValue` attribute because reading out the `Value` before it's changed to store default values (for `Reset to Default` button and such) made me immediately run into the next bug when trying to fix this (you can try to figure out what that bug was :P). This should be much less error-prone.