### PR TITLE
Add Event to Notify ASL Script Change

### DIFF
--- a/Component.cs
+++ b/Component.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
@@ -16,6 +16,8 @@ namespace LiveSplit.UI.Components
 
         // public so other components (ASLVarViewer) can access
         public ASLScript Script { get; private set; }
+
+        public event EventHandler ScriptChanged;
 
         private bool _do_reload;
         private string _old_script_path;
@@ -106,6 +108,11 @@ namespace LiveSplit.UI.Components
                     else
                     {
                         LoadScript();
+                    }
+
+                    if (ScriptChanged != null)
+                    {
+                        ScriptChanged(this, new EventArgs());
                     }
                 }
                 catch (Exception ex)

--- a/Component.cs
+++ b/Component.cs
@@ -58,6 +58,15 @@ namespace LiveSplit.UI.Components
         public override void Dispose()
         {
             ScriptCleanup();
+            
+            try
+            {
+                ScriptChanged?.Invoke(this, EventArgs.Empty);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex);
+            }
 
             _fs_watcher?.Dispose();
             _update_timer?.Dispose();
@@ -110,10 +119,7 @@ namespace LiveSplit.UI.Components
                         LoadScript();
                     }
 
-                    if (ScriptChanged != null)
-                    {
-                        ScriptChanged(this, new EventArgs());
-                    }
+                    ScriptChanged?.Invoke(this, EventArgs.Empty);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
This will allow other components that use the ASLScript introspection (like ASLVarViewer) to more easily detect when a Script changes.  This allows for a more defined life-cycle rather than trying to connect at certain events like start or end of run.

This would enable zoton2's scenario to better enable using ASLVarViewer in the future for 1.7 as a debugger to display script values in LiveSplit vs. using dbgview print statements by allowing it to update its reference as soon as a script change is made and detected by LiveSplit.