### PR TITLE
Fix ASL Settings not being grayed out properly

### DIFF
--- a/ComponentSettings.cs
+++ b/ComponentSettings.cs
@@ -367,7 +367,7 @@ namespace LiveSplit.UI.Components
             {
                 UpdateNodesInTree(n => {
                     n.ForeColor = node.Checked ? SystemColors.WindowText : SystemColors.GrayText;
-                    return n.Checked;
+                    return n.Checked || !node.Checked;
                 }, node.Nodes);
             }
         }


### PR DESCRIPTION
The grayout wasn't properly being propagated through child nodes if all
the settings were initially off.