### PR TITLE
Add ASLSettingsReader.ContainsKey(string key)

### DIFF
--- a/ASL/ASLSettings.cs
+++ b/ASL/ASLSettings.cs
@@ -156,6 +156,11 @@ namespace LiveSplit.ASL
         {
             get { return _s.GetSettingValue(id); }
         }
+        
+        public bool ContainsKey(string key)
+        {
+            return _s.Settings.ContainsKey(key);   
+        }
 
         public bool StartEnabled
         {


### PR DESCRIPTION
This method checks if ASLSettings contains a specific setting.