### PR TITLE
Allow negative numbers for offsets

### DIFF
--- a/ASL/ASLGrammar.cs
+++ b/ASL/ASLGrammar.cs
@@ -11,6 +11,7 @@ namespace LiveSplit.ASL
         {
             var string_lit = TerminalFactory.CreateCSharpString("string");
             var number = TerminalFactory.CreateCSharpNumber("number");
+            number.Options |= NumberOptions.AllowSign;
             var identifier = TerminalFactory.CreateCSharpIdentifier("identifier");
             var code = new CustomTerminal("code", MatchCodeTerminal);
 


### PR DESCRIPTION
Following this issue LiveSplit/LiveSplit#1151 ASL does not allow negative number for offsets. Even after this PR this will remain true for hexadecimal but will allow negative integers.