### PR TITLE
Fixed invalid cast exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,6 @@ $RECYCLE.BIN/
 *.msi
 *.msm
 *.msp
+
+# Visual Studio .vs Folder
+/.vs

--- a/ASL/ASLParser.cs
+++ b/ASL/ASLParser.cs
@@ -51,8 +51,8 @@ namespace LiveSplit.ASL
                     var module =
                         child_nodes[3].ChildNodes.Take(1).Select(x => (string)x.Token.Value).FirstOrDefault() ??
                         string.Empty;
-                    var module_base = child_nodes[4].ChildNodes.Select(x => (long)x.Token.Value).First();
-                    var offsets = child_nodes[4].ChildNodes.Skip(1).Select(x => (long)x.Token.Value).ToArray();
+                    var module_base = child_nodes[4].ChildNodes.Select(x => Convert.ToInt64(x.Token.Value)).First();
+                    var offsets = child_nodes[4].ChildNodes.Skip(1).Select(x => Convert.ToInt64(x.Token.Value)).ToArray();
                     var value_definition = new ASLValueDefinition()
                     {
                         Identifier = identifier,


### PR DESCRIPTION
The casting a parsing token into a long was giving me this error:

`LiveSplit.exe Error: 0 : Specified cast is not valid.
   at LiveSplit.ASL.ASLParser.<>c.<Parse>b__0_5(ParseTreeNode x) in C:\Users\Desktop\Source\Repos\DerKO9\LiveSplit\LiveSplit\Components\LiveSplit.ScriptableAutoSplit\ASL\ASLParser.cs:line 54
   at System.Linq.Enumerable.WhereSelectListIterator2.MoveNext()
   at System.Linq.Enumerable.First[TSource](IEnumerable1 source)
   at LiveSplit.ASL.ASLParser.Parse(String code) in C:\Users\Desktop\Source\Repos\DerKO9\LiveSplit\LiveSplit\Components\LiveSplit.ScriptableAutoSplit\ASL\ASLParser.cs:line 54
   at LiveSplit.UI.Components.ASLComponent.LoadScript() in C:\Users\Desktop\Source\Repos\DerKO9\LiveSplit\LiveSplit\Components\LiveSplit.ScriptableAutoSplit\Component.cs:line 154
   at LiveSplit.UI.Components.ASLComponent.UpdateScript() in C:\Users\Desktop\Source\Repos\DerKO9\LiveSplit\LiveSplit\Components\LiveSplit.ScriptableAutoSplit\Component.cs:line 119`

So I replaced it with Convert.ToInt64() conversion by inspiration of this [stackoverflow post](https://stackoverflow.com/questions/3953391/why-does-intobject10m-throw-specified-cast-is-not-valid-exception)

After making this change, loading and running my ASL script worked.

My .vs folder almost made it into the commits so I added a .vs exception in the .gitignore