### PR TITLE
Component.cs: ASLComponent: also reload asl script on file rename

### DIFF
--- a/Component.cs
+++ b/Component.cs
@@ -41,6 +41,11 @@ namespace LiveSplit.UI.Components
                 _do_reload = true;
             };
 
+            _fs_watcher.Renamed += async (sender, args) => {
+              await Task.Delay(200);
+              _do_reload = true;
+            };
+
             // -try- to run a little faster than 60hz
             // note: Timer isn't very reliable and quite often takes ~30ms
             // we need to switch to threading
@@ -58,7 +63,7 @@ namespace LiveSplit.UI.Components
         public override void Dispose()
         {
             ScriptCleanup();
-            
+
             try
             {
                 ScriptChanged?.Invoke(this, EventArgs.Empty);

--- a/Component.cs
+++ b/Component.cs
@@ -36,15 +36,15 @@ namespace LiveSplit.UI.Components
             _settings = new ComponentSettings();
 
             _fs_watcher = new FileSystemWatcher();
-            _fs_watcher.Changed += async (sender, args) => {
-                await Task.Delay(200);
-                _do_reload = true;
-            };
 
-            _fs_watcher.Renamed += async (sender, args) => {
+            async void handler<T>(object sender, T args)
+            {
               await Task.Delay(200);
               _do_reload = true;
             };
+
+            _fs_watcher.Changed += handler;
+            _fs_watcher.Renamed += handler;
 
             // -try- to run a little faster than 60hz
             // note: Timer isn't very reliable and quite often takes ~30ms


### PR DESCRIPTION
When saving an asl script with Visual Studio it won't be recompiled by LiveSplit. The reason is, that Visual Studio does never change a file when saving but creates a new temporary file, deletes the old one and renames the temporary file to the old file name.
(See https://stackoverflow.com/a/681078)

This PR fixes that issue by adding a renamed handler to the file watcher. That way a saved asl script which is saved with Visual Studio is also detected properly.