### PR TITLE
Allow non-user checking of grayed out checkboxes

### DIFF
--- a/ComponentSettings.cs
+++ b/ComponentSettings.cs
@@ -433,7 +433,11 @@ namespace LiveSplit.UI.Components
 
         private void settingsTree_BeforeCheck(object sender, TreeViewCancelEventArgs e)
         {
-            e.Cancel = e.Node.ForeColor == SystemColors.GrayText;
+            // Confirm that the user initiated the selection
+            if (e.Action != TreeViewAction.Unknown)
+            {
+                e.Cancel = e.Node.ForeColor == SystemColors.GrayText;
+            }
         }
 
         // Custom Settings Button Events


### PR DESCRIPTION
Hopefully fixes https://github.com/LiveSplit/LiveSplit.ScriptableAutoSplit/issues/58 (I haven't tested it 🙃) [Inspired by code from these Microsoft Docs](https://learn.microsoft.com/en-us/dotnet/api/system.windows.forms.treevieweventargs.action?view=netframework-4.6.1#system-windows-forms-treevieweventargs-action)