### PR TITLE
Ensure timer events being unsubscribed (#62)

### DIFF
--- a/ASL/ASLScript.cs
+++ b/ASL/ASLScript.cs
@@ -160,7 +160,6 @@ namespace LiveSplit.ASL
         public void RunShutdown(LiveSplitState state)
         {
             Debug("Running shutdown");
-            RunMethod(_methods.shutdown, state);
 
             if(!_methods.onStart.IsEmpty)
                 state.OnStart -= RunOnStart;
@@ -168,6 +167,8 @@ namespace LiveSplit.ASL
                 state.OnSplit -= RunOnSplit;
             if(!_methods.onReset.IsEmpty)
                 state.OnReset -= RunOnReset;
+
+            RunMethod(_methods.shutdown, state);
         }
 
         private void TryConnect(LiveSplitState state)


### PR DESCRIPTION
Reopens #63, which was accidentally closed.

Moves the potentially throwing method `ASLScript.RunMethod` in the `ASLScript.RunShutdown` method below the code that unsubscribes the timer events. Closes https://github.com/LiveSplit/LiveSplit.ScriptableAutoSplit/issues/62.