### PR TITLE
Add `.editorconfig` & apply style rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,368 @@
+root = true
+
+# All files
+[*]
+indent_style             = space
+trim_trailing_whitespace = true
+
+# New line preferences
+end_of_line          = crlf
+insert_final_newline = true
+
+# Xml project files
+[*.{csproj,proj}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets}]
+indent_size = 2
+
+# Other markup files
+[*.{json,xml,yml}]
+indent_size = 2
+
+# Markdown files
+[*.md]
+indent_size              = 2
+trim_trailing_whitespace = false
+
+# C# files
+[*.cs]
+indent_size = 4
+
+
+#### C# Style Rules ####
+[*.cs]
+
+file_header_template = unset
+
+# Uncategorized rules (diagnostics without a property equivalent)
+
+dotnet_diagnostic.IDE0001.severity = suggestion # Simplify name
+dotnet_diagnostic.IDE0002.severity = suggestion # Simplify member access
+dotnet_diagnostic.IDE0004.severity = warning    # Remove unnecessary cast
+dotnet_diagnostic.IDE0005.severity = warning    # Remove unnecessary import
+dotnet_diagnostic.IDE0035.severity = suggestion # Remove unreachable code
+dotnet_diagnostic.IDE0050.severity = warning    # Convert anonymous type to tuple
+dotnet_diagnostic.IDE0051.severity = suggestion # Remove unused private member
+dotnet_diagnostic.IDE0052.severity = suggestion # Remove unread private member
+dotnet_diagnostic.IDE0064.severity = suggestion # Make struct fields writable
+dotnet_diagnostic.IDE0080.severity = warning    # Remove unnecessary suppression operator
+dotnet_diagnostic.IDE0082.severity = warning    # Convert `typeof` to `nameof`
+dotnet_diagnostic.IDE0100.severity = warning    # Remove unnecessary equality operator
+dotnet_diagnostic.IDE0110.severity = suggestion # Remove unnecessary discard
+dotnet_diagnostic.IDE0120.severity = warning    # Simplify LINQ expression
+dotnet_diagnostic.IDE0280.severity = warning    # Use `nameof`
+
+
+#### .NET Coding Conventions ####
+
+# Organize usings
+dotnet_separate_import_directive_groups = true
+dotnet_sort_system_directives_first     = true
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event    = false:warning
+dotnet_style_qualification_for_field    = false:warning
+dotnet_style_qualification_for_method   = false:warning
+dotnet_style_qualification_for_property = false:warning
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access             = true:warning
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_binary_operators      = always_for_clarity:warning
+dotnet_style_parentheses_in_other_operators             = never_if_unnecessary:warning
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:warning
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
+
+# Expression-level preferences
+dotnet_style_coalesce_expression                                 = true:suggestion
+dotnet_style_collection_initializer                              = true:warning
+dotnet_style_explicit_tuple_names                                = true:warning
+dotnet_style_null_propagation                                    = true:suggestion
+dotnet_style_object_initializer                                  = true:warning
+dotnet_style_operator_placement_when_wrapping                    = beginning_of_line
+dotnet_style_prefer_auto_properties                              = true:warning
+dotnet_style_prefer_collection_expression                        = true:suggestion
+dotnet_style_prefer_compound_assignment                          = true:warning
+dotnet_style_prefer_conditional_expression_over_assignment       = true:silent
+dotnet_style_prefer_conditional_expression_over_return           = false:silent
+dotnet_style_prefer_foreach_explicit_cast_in_source              = when_strongly_typed
+dotnet_style_prefer_inferred_anonymous_type_member_names         = false:suggestion
+dotnet_style_prefer_inferred_tuple_names                         = false:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
+dotnet_style_prefer_simplified_boolean_expressions               = true:suggestion
+dotnet_style_prefer_simplified_interpolation                     = true:suggestion
+csharp_style_throw_expression                                    = false:warning
+
+# Field preferences
+dotnet_style_readonly_field = true:warning
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all:suggestion
+
+# Suppression preferences
+dotnet_remove_unnecessary_suppression_exclusions = suggestion
+
+# New line preferences
+dotnet_style_allow_multiple_blank_lines_experimental              = false:warning
+dotnet_style_allow_statement_immediately_after_block_experimental = false:warning
+
+
+#### C# Coding Conventions ####
+
+# readonly preferences
+csharp_style_prefer_readonly_struct        = true:warning
+csharp_style_prefer_readonly_struct_member = true:warning
+
+# var preferences
+csharp_style_var_elsewhere             = false:suggestion
+csharp_style_var_for_built_in_types    = false:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors       = when_on_single_line:suggestion
+csharp_style_expression_bodied_constructors    = false:warning
+csharp_style_expression_bodied_indexers        = when_on_single_line:suggestion
+csharp_style_expression_bodied_lambdas         = when_on_single_line:suggestion
+csharp_style_expression_bodied_local_functions = false:warning
+csharp_style_expression_bodied_methods         = false:warning
+csharp_style_expression_bodied_operators       = false:warning
+csharp_style_expression_bodied_properties      = when_on_single_line:suggestion
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_prefer_not_pattern                       = true:warning
+csharp_style_prefer_extended_property_pattern         = true:warning
+csharp_style_prefer_pattern_matching                  = true:suggestion
+csharp_style_prefer_switch_expression                 = true:suggestion
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Modifier preferences
+csharp_prefer_static_local_function = true:warning
+csharp_preferred_modifier_order     = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:silent
+
+# Code-block preferences
+csharp_prefer_braces                        = true:warning
+csharp_prefer_simple_using_statement        = true:warning
+csharp_style_prefer_method_group_conversion = true:suggestion
+csharp_style_prefer_top_level_statements    = true:suggestion
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression                     = true:warning
+csharp_style_deconstructed_variable_declaration             = true:warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
+csharp_style_inlined_variable_declaration                   = true:warning
+csharp_style_pattern_local_over_anonymous_function          = true:warning
+csharp_style_prefer_index_operator                          = true:warning
+csharp_style_prefer_local_over_anonymous_function           = true:warning
+csharp_style_prefer_null_check_over_type_check              = true:warning
+csharp_style_prefer_range_operator                          = true:warning
+csharp_style_prefer_tuple_swap                              = true:warning
+csharp_style_prefer_utf8_string_literals                    = true:suggestion
+csharp_style_unused_value_assignment_preference             = discard_variable:none
+csharp_style_unused_value_expression_statement_preference   = discard_variable:none
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace:warning
+
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch                                                      = true
+csharp_new_line_before_else                                                       = true
+csharp_new_line_before_finally                                                    = true
+csharp_new_line_before_members_in_anonymous_types                                 = true
+csharp_new_line_before_members_in_object_initializers                             = true
+csharp_new_line_before_open_brace                                                 = all
+csharp_new_line_between_query_expression_clauses                                  = true
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false:warning
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental  = false:warning
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = false:warning
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental            = false:warning
+csharp_style_allow_embedded_statements_on_same_line_experimental                  = false:warning
+
+# Indentation preferences
+csharp_indent_block_contents           = true
+csharp_indent_braces                   = false
+csharp_indent_case_contents            = true
+csharp_indent_case_contents_when_block = false
+csharp_indent_labels                   = one_less_than_current
+csharp_indent_switch_labels            = true
+
+# Space preferences
+csharp_space_after_cast                                                  = false
+csharp_space_after_colon_in_inheritance_clause                           = true
+csharp_space_after_comma                                                 = true
+csharp_space_after_dot                                                   = false
+csharp_space_after_keywords_in_control_flow_statements                   = true
+csharp_space_after_semicolon_in_for_statement                            = true
+csharp_space_around_binary_operators                                     = before_and_after
+csharp_space_around_declaration_statements                               = false
+csharp_space_before_colon_in_inheritance_clause                          = true
+csharp_space_before_comma                                                = false
+csharp_space_before_dot                                                  = false
+csharp_space_before_open_square_brackets                                 = false
+csharp_space_before_semicolon_in_for_statement                           = false
+csharp_space_between_empty_square_brackets                               = false
+csharp_space_between_method_call_empty_parameter_list_parentheses        = false
+csharp_space_between_method_call_name_and_opening_parenthesis            = false
+csharp_space_between_method_call_parameter_list_parentheses              = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis        = false
+csharp_space_between_method_declaration_parameter_list_parentheses       = false
+csharp_space_between_parentheses                                         = false
+csharp_space_between_square_brackets                                     = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks     = true
+csharp_preserve_single_line_statements = true
+
+# Namespace preferences
+csharp_style_namespace_declarations = file_scoped:warning
+dotnet_style_namespace_match_folder = false
+
+# Constructor preferences
+csharp_style_prefer_primary_constructors = false:none
+
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.symbols  = types_and_namespaces
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.interfaces_should_be_ipascalcase.severity = suggestion
+dotnet_naming_rule.interfaces_should_be_ipascalcase.symbols  = interfaces
+dotnet_naming_rule.interfaces_should_be_ipascalcase.style    = ipascalcase
+
+dotnet_naming_rule.non_field_members_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascalcase.symbols  = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.constant_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascalcase.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.symbols  = public_static_fields
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.public_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.public_fields_should_be_pascalcase.symbols  = public_fields
+dotnet_naming_rule.public_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.private_fields_should_be__camelcase.severity = suggestion
+dotnet_naming_rule.private_fields_should_be__camelcase.symbols  = private_fields
+dotnet_naming_rule.private_fields_should_be__camelcase.style    = _camelcase
+
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.severity = warning
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.symbols  = type_parameters
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.style    = tpascalcase
+
+dotnet_naming_rule.parameters_should_be_camelcase.severity = suggestion
+dotnet_naming_rule.parameters_should_be_camelcase.symbols  = parameters
+dotnet_naming_rule.parameters_should_be_camelcase.style    = camelcase
+
+dotnet_naming_rule.local_constants_should_be_pascalcase.severity = warning
+dotnet_naming_rule.local_constants_should_be_pascalcase.symbols  = local_constants
+dotnet_naming_rule.local_constants_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.local_variables_should_be_camelcase.severity = warning
+dotnet_naming_rule.local_variables_should_be_camelcase.symbols  = local_variables
+dotnet_naming_rule.local_variables_should_be_camelcase.style    = camelcase
+
+dotnet_naming_rule.local_functions_should_be_camelcase.severity = warning
+dotnet_naming_rule.local_functions_should_be_camelcase.symbols  = local_functions
+dotnet_naming_rule.local_functions_should_be_camelcase.style    = camelcase
+
+# Symbol specifications
+
+dotnet_naming_symbols.types_and_namespaces.applicable_kinds           = namespace, class, struct, interface, enum
+dotnet_naming_symbols.types_and_namespaces.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types_and_namespaces.required_modifiers         =
+
+dotnet_naming_symbols.interfaces.applicable_kinds           = interface
+dotnet_naming_symbols.interfaces.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interfaces.required_modifiers         =
+
+dotnet_naming_symbols.non_field_members.applicable_kinds           = property, event, delegate, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers         =
+
+dotnet_naming_symbols.constant_fields.applicable_kinds           = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.constant_fields.required_modifiers         = const
+
+dotnet_naming_symbols.public_static_fields.applicable_kinds           = field
+dotnet_naming_symbols.public_static_fields.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public_static_fields.required_modifiers         = static
+
+dotnet_naming_symbols.public_fields.applicable_kinds           = field
+dotnet_naming_symbols.public_fields.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public_fields.required_modifiers         =
+
+dotnet_naming_symbols.private_fields.applicable_kinds           = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private, protected, protected_internal, private_protected
+dotnet_naming_symbols.private_fields.required_modifiers         =
+
+dotnet_naming_symbols.type_parameters.applicable_kinds           = type_parameter
+dotnet_naming_symbols.type_parameters.applicable_accessibilities = *
+dotnet_naming_symbols.type_parameters.required_modifiers         =
+
+dotnet_naming_symbols.parameters.applicable_kinds           = parameter
+dotnet_naming_symbols.parameters.applicable_accessibilities = *
+dotnet_naming_symbols.parameters.required_modifiers         =
+
+dotnet_naming_symbols.local_constants.applicable_kinds           = local
+dotnet_naming_symbols.local_constants.applicable_accessibilities = local
+dotnet_naming_symbols.local_constants.required_modifiers         = const
+
+dotnet_naming_symbols.local_variables.applicable_kinds           = local
+dotnet_naming_symbols.local_variables.applicable_accessibilities = local
+dotnet_naming_symbols.local_variables.required_modifiers         =
+
+dotnet_naming_symbols.local_functions.applicable_kinds           = local_function
+dotnet_naming_symbols.local_functions.applicable_accessibilities = local
+dotnet_naming_symbols.local_functions.required_modifiers         =
+
+# Naming styles
+
+dotnet_naming_style.pascalcase.required_prefix =
+dotnet_naming_style.pascalcase.required_suffix =
+dotnet_naming_style.pascalcase.word_separator  =
+dotnet_naming_style.pascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.ipascalcase.required_prefix = I
+dotnet_naming_style.ipascalcase.required_suffix =
+dotnet_naming_style.ipascalcase.word_separator  =
+dotnet_naming_style.ipascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.tpascalcase.required_prefix = T
+dotnet_naming_style.tpascalcase.required_suffix =
+dotnet_naming_style.tpascalcase.word_separator  =
+dotnet_naming_style.tpascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.camelcase.required_prefix =
+dotnet_naming_style.camelcase.required_suffix =
+dotnet_naming_style.camelcase.word_separator  =
+dotnet_naming_style.camelcase.capitalization  = camel_case
+
+dotnet_naming_style._camelcase.required_prefix = _
+dotnet_naming_style._camelcase.required_suffix =
+dotnet_naming_style._camelcase.word_separator  =
+dotnet_naming_style._camelcase.capitalization  = camel_case
+
+
+#### Suppressions ####

--- a/props/LiveSplit.ScriptableAutoSplit.props
+++ b/props/LiveSplit.ScriptableAutoSplit.props
@@ -2,6 +2,8 @@
 
   <!-- Project properties. -->
   <PropertyGroup>
+    <LangVersion>12</LangVersion>
+
     <Nullable>disable</Nullable>
   </PropertyGroup>
 

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLExceptions.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLExceptions.cs
@@ -34,7 +34,7 @@ public class ASLCompilerException : Exception
         var sb = new StringBuilder($"'{method.Name ?? "(no name)"}' method compilation errors:");
         foreach (CompilerError error in errors)
         {
-            error.Line = error.Line + method.LineOffset;
+            error.Line += method.LineOffset;
             sb.Append($"\nLine {error.Line}, Col {error.Column}: {(error.IsWarning ? "warning" : "error")} {error.ErrorNumber}: {error.ErrorText}");
         }
 

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLExceptions.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLExceptions.cs
@@ -19,7 +19,7 @@ public class ASLCompilerException : Exception
         CompilerErrors = errors;
     }
 
-    static string GetMessage(ASLMethod method, CompilerErrorCollection errors)
+    private static string GetMessage(ASLMethod method, CompilerErrorCollection errors)
     {
         if (method == null)
             throw new ArgumentNullException(nameof(method));
@@ -42,7 +42,7 @@ public class ASLRuntimeException : Exception
         : base(GetMessage(method, inner_exception), inner_exception)
     { }
 
-    static string GetMessage(ASLMethod method, Exception inner_exception)
+    private static string GetMessage(ASLMethod method, Exception inner_exception)
     {
         if (method == null)
             throw new ArgumentNullException(nameof(method));

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLExceptions.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLExceptions.cs
@@ -62,12 +62,12 @@ public class ASLRuntimeException : Exception
 
         var stack_trace = new StackTrace(inner_exception, true);
         var stack_trace_sb = new StringBuilder();
-        foreach (var frame in stack_trace.GetFrames())
+        foreach (StackFrame frame in stack_trace.GetFrames())
         {
-            var frame_method = frame.GetMethod();
-            var frame_module = frame_method.Module;
+            System.Reflection.MethodBase frame_method = frame.GetMethod();
+            System.Reflection.Module frame_module = frame_method.Module;
 
-            var frame_asl_method = method;
+            ASLMethod frame_asl_method = method;
             if (method.ScriptMethods != null)
             {
                 frame_asl_method = method.ScriptMethods.FirstOrDefault(m => frame_module == m.Module);
@@ -81,17 +81,17 @@ public class ASLRuntimeException : Exception
                 continue;
             }
 
-            var frame_line = frame.GetFileLineNumber();
+            int frame_line = frame.GetFileLineNumber();
             if (frame_line > 0)
             {
-                var line = frame_line + frame_asl_method.LineOffset;
+                int line = frame_line + frame_asl_method.LineOffset;
                 stack_trace_sb.Append($"\n   at ASL line {line} in '{frame_asl_method.Name}'");
             }
         }
 
-        var exception_name = inner_exception.GetType().FullName;
-        var method_name = method.Name ?? "(no name)";
-        var exception_message = inner_exception.Message;
+        string exception_name = inner_exception.GetType().FullName;
+        string method_name = method.Name ?? "(no name)";
+        string exception_message = inner_exception.Message;
         return $"Exception thrown: '{exception_name}' in '{method_name}' method:\n{exception_message}\n{stack_trace_sb}";
     }
 }

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLExceptions.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLExceptions.cs
@@ -92,6 +92,6 @@ public class ASLRuntimeException : Exception
         var exception_name = inner_exception.GetType().FullName;
         var method_name = method.Name ?? "(no name)";
         var exception_message = inner_exception.Message;
-        return $"Exception thrown: '{exception_name}' in '{method_name}' method:\n{exception_message}\n{stack_trace_sb.ToString()}";
+        return $"Exception thrown: '{exception_name}' in '{method_name}' method:\n{exception_message}\n{stack_trace_sb}";
     }
 }

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLExceptions.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLExceptions.cs
@@ -4,80 +4,79 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text;
 
-namespace LiveSplit.ASL
+namespace LiveSplit.ASL;
+
+public class ASLCompilerException : Exception
 {
-    public class ASLCompilerException : Exception
+    public ASLMethod Method { get; }
+
+    public CompilerErrorCollection CompilerErrors { get; }
+
+    public ASLCompilerException(ASLMethod method, CompilerErrorCollection errors)
+        : base(GetMessage(method, errors))
     {
-        public ASLMethod Method { get; }
-
-        public CompilerErrorCollection CompilerErrors { get; }
-
-        public ASLCompilerException(ASLMethod method, CompilerErrorCollection errors)
-            : base(GetMessage(method, errors))
-        {
-            Method = method;
-            CompilerErrors = errors;
-        }
-
-        static string GetMessage(ASLMethod method, CompilerErrorCollection errors)
-        {
-            if (method == null)
-                throw new ArgumentNullException(nameof(method));
-            if (errors == null)
-                throw new ArgumentNullException(nameof(errors));
-
-            var sb = new StringBuilder($"'{method.Name ?? "(no name)"}' method compilation errors:");
-            foreach (CompilerError error in errors)
-            {
-                error.Line = error.Line + method.LineOffset;
-                sb.Append($"\nLine {error.Line}, Col {error.Column}: {(error.IsWarning ? "warning" : "error")} {error.ErrorNumber}: {error.ErrorText}");
-            }
-            return sb.ToString();
-        }
+        Method = method;
+        CompilerErrors = errors;
     }
 
-    public class ASLRuntimeException : Exception
+    static string GetMessage(ASLMethod method, CompilerErrorCollection errors)
     {
-        public ASLRuntimeException(ASLMethod method, Exception inner_exception)
-            : base(GetMessage(method, inner_exception), inner_exception)
-        { }
+        if (method == null)
+            throw new ArgumentNullException(nameof(method));
+        if (errors == null)
+            throw new ArgumentNullException(nameof(errors));
 
-        static string GetMessage(ASLMethod method, Exception inner_exception)
+        var sb = new StringBuilder($"'{method.Name ?? "(no name)"}' method compilation errors:");
+        foreach (CompilerError error in errors)
         {
-            if (method == null)
-                throw new ArgumentNullException(nameof(method));
-            if (inner_exception == null)
-                throw new ArgumentNullException(nameof(inner_exception));
-
-            var stack_trace = new StackTrace(inner_exception, true);
-            var stack_trace_sb = new StringBuilder();
-            foreach (var frame in stack_trace.GetFrames())
-            {
-                var frame_method = frame.GetMethod();
-                var frame_module = frame_method.Module;
-
-                var frame_asl_method = method;
-                if (method.ScriptMethods != null)
-                {
-                    frame_asl_method = method.ScriptMethods.FirstOrDefault(m => frame_module == m.Module);
-                    if (frame_asl_method == null)
-                        continue;
-                }
-                else if (frame_module != method.Module)
-                    continue;
-
-                var frame_line = frame.GetFileLineNumber();
-                if (frame_line > 0)
-                {
-                    var line = frame_line + frame_asl_method.LineOffset;
-                    stack_trace_sb.Append($"\n   at ASL line {line} in '{frame_asl_method.Name}'");
-                }
-            }
-
-            var exception_name = inner_exception.GetType().FullName;
-            var method_name = method.Name ?? "(no name)";
-            var exception_message = inner_exception.Message;
-            return $"Exception thrown: '{exception_name}' in '{method_name}' method:\n{exception_message}\n{stack_trace_sb.ToString()}";
+            error.Line = error.Line + method.LineOffset;
+            sb.Append($"\nLine {error.Line}, Col {error.Column}: {(error.IsWarning ? "warning" : "error")} {error.ErrorNumber}: {error.ErrorText}");
         }
+        return sb.ToString();
+    }
+}
+
+public class ASLRuntimeException : Exception
+{
+    public ASLRuntimeException(ASLMethod method, Exception inner_exception)
+        : base(GetMessage(method, inner_exception), inner_exception)
+    { }
+
+    static string GetMessage(ASLMethod method, Exception inner_exception)
+    {
+        if (method == null)
+            throw new ArgumentNullException(nameof(method));
+        if (inner_exception == null)
+            throw new ArgumentNullException(nameof(inner_exception));
+
+        var stack_trace = new StackTrace(inner_exception, true);
+        var stack_trace_sb = new StringBuilder();
+        foreach (var frame in stack_trace.GetFrames())
+        {
+            var frame_method = frame.GetMethod();
+            var frame_module = frame_method.Module;
+
+            var frame_asl_method = method;
+            if (method.ScriptMethods != null)
+            {
+                frame_asl_method = method.ScriptMethods.FirstOrDefault(m => frame_module == m.Module);
+                if (frame_asl_method == null)
+                    continue;
+            }
+            else if (frame_module != method.Module)
+                continue;
+
+            var frame_line = frame.GetFileLineNumber();
+            if (frame_line > 0)
+            {
+                var line = frame_line + frame_asl_method.LineOffset;
+                stack_trace_sb.Append($"\n   at ASL line {line} in '{frame_asl_method.Name}'");
+            }
+        }
+
+        var exception_name = inner_exception.GetType().FullName;
+        var method_name = method.Name ?? "(no name)";
+        var exception_message = inner_exception.Message;
+        return $"Exception thrown: '{exception_name}' in '{method_name}' method:\n{exception_message}\n{stack_trace_sb.ToString()}";
     }
 }

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLExceptions.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLExceptions.cs
@@ -22,9 +22,14 @@ public class ASLCompilerException : Exception
     private static string GetMessage(ASLMethod method, CompilerErrorCollection errors)
     {
         if (method == null)
+        {
             throw new ArgumentNullException(nameof(method));
+        }
+
         if (errors == null)
+        {
             throw new ArgumentNullException(nameof(errors));
+        }
 
         var sb = new StringBuilder($"'{method.Name ?? "(no name)"}' method compilation errors:");
         foreach (CompilerError error in errors)
@@ -32,6 +37,7 @@ public class ASLCompilerException : Exception
             error.Line = error.Line + method.LineOffset;
             sb.Append($"\nLine {error.Line}, Col {error.Column}: {(error.IsWarning ? "warning" : "error")} {error.ErrorNumber}: {error.ErrorText}");
         }
+
         return sb.ToString();
     }
 }
@@ -45,9 +51,14 @@ public class ASLRuntimeException : Exception
     private static string GetMessage(ASLMethod method, Exception inner_exception)
     {
         if (method == null)
+        {
             throw new ArgumentNullException(nameof(method));
+        }
+
         if (inner_exception == null)
+        {
             throw new ArgumentNullException(nameof(inner_exception));
+        }
 
         var stack_trace = new StackTrace(inner_exception, true);
         var stack_trace_sb = new StringBuilder();
@@ -61,10 +72,14 @@ public class ASLRuntimeException : Exception
             {
                 frame_asl_method = method.ScriptMethods.FirstOrDefault(m => frame_module == m.Module);
                 if (frame_asl_method == null)
+                {
                     continue;
+                }
             }
             else if (frame_module != method.Module)
+            {
                 continue;
+            }
 
             var frame_line = frame.GetFileLineNumber();
             if (frame_line > 0)

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLGrammar.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLGrammar.cs
@@ -1,96 +1,96 @@
 ﻿using System.Linq;
+
 using Irony.Parsing;
 
-namespace LiveSplit.ASL
+namespace LiveSplit.ASL;
+
+[Language("asl", "1.0", "Auto Split Language grammar")]
+public class ASLGrammar : Grammar
 {
-    [Language("asl", "1.0", "Auto Split Language grammar")]
-    public class ASLGrammar : Grammar
+    public ASLGrammar()
+        : base(true)
     {
-        public ASLGrammar()
-            : base(true)
+        var string_lit = TerminalFactory.CreateCSharpString("string");
+        var number = TerminalFactory.CreateCSharpNumber("number");
+        number.Options |= NumberOptions.AllowSign;
+        var identifier = TerminalFactory.CreateCSharpIdentifier("identifier");
+        var code = new CustomTerminal("code", MatchCodeTerminal);
+
+        var single_line_comment = new CommentTerminal("SingleLineComment", "//", "\r", "\n", "\u2085", "\u2028", "\u2029");
+        var delimited_comment = new CommentTerminal("DelimitedComment", "/*", "*/");
+        NonGrammarTerminals.Add(single_line_comment);
+        NonGrammarTerminals.Add(delimited_comment);
+
+        var state = new KeyTerm("state", "state");
+        var init = new KeyTerm("init", "init");
+        var exit = new KeyTerm("exit", "exit");
+        var update = new KeyTerm("update", "update");
+        var start = new KeyTerm("start", "start");
+        var split = new KeyTerm("split", "split");
+        var reset = new KeyTerm("reset", "reset");
+        var startup = new KeyTerm("startup", "startup");
+        var shutdown = new KeyTerm("shutdown", "shutdown");
+        var isLoading = new KeyTerm("isLoading", "isLoading");
+        var gameTime = new KeyTerm("gameTime", "gameTime");
+        var onStart = new KeyTerm("onStart", "onStart");
+        var onSplit = new KeyTerm("onSplit", "onSplit");
+        var onReset = new KeyTerm("onReset", "onReset");
+        var comma = ToTerm(",", "comma");
+        var semi = ToTerm(";", "semi");
+
+        var root = new NonTerminal("root");
+        var state_def = new NonTerminal("stateDef");
+        var version = new NonTerminal("version");
+        var state_list = new NonTerminal("stateList");
+        var method_list = new NonTerminal("methodList");
+        var var_list = new NonTerminal("varList");
+        var var = new NonTerminal("var");
+        var module = new NonTerminal("module");
+        var method = new NonTerminal("method");
+        var offset_list = new NonTerminal("offsetList");
+        var offset = new NonTerminal("offset");
+        var method_type = new NonTerminal("methodType");
+
+        root.Rule = state_list + method_list;
+        version.Rule = (comma + string_lit) | Empty;
+        state_def.Rule = state + "(" + string_lit + version + ")" + "{" + var_list + "}";
+        state_list.Rule = MakeStarRule(state_list, state_def);
+        method_list.Rule = MakeStarRule(method_list, method);
+        var_list.Rule = MakeStarRule(var_list, semi, var);
+        module.Rule = (string_lit + comma) | Empty;
+        var.Rule = (identifier + identifier + ":" + module + offset_list) | Empty;
+        method.Rule = (method_type + "{" + code + "}") | Empty;
+        offset_list.Rule = MakePlusRule(offset_list, comma, offset);
+        offset.Rule = number;
+        method_type.Rule = init | exit | update | start | split | isLoading | gameTime | reset | startup | shutdown | onStart | onSplit | onReset;
+
+        Root = root;
+
+        MarkTransient(var_list, method_list, offset, method_type);
+
+        LanguageFlags = LanguageFlags.NewLineBeforeEOF;
+    }
+
+    private static Token MatchCodeTerminal(Terminal terminal, ParsingContext context, ISourceStream source)
+    {
+        var remaining = source.Text.Substring(source.Location.Position);
+        var stack = 1;
+        var token = "";
+
+        while (stack > 0)
         {
-            var string_lit = TerminalFactory.CreateCSharpString("string");
-            var number = TerminalFactory.CreateCSharpNumber("number");
-            number.Options |= NumberOptions.AllowSign;
-            var identifier = TerminalFactory.CreateCSharpIdentifier("identifier");
-            var code = new CustomTerminal("code", MatchCodeTerminal);
+            var index = remaining.IndexOf('}') + 1;
+            var cut = remaining.Substring(0, index);
 
-            var single_line_comment = new CommentTerminal("SingleLineComment", "//", "\r", "\n", "\u2085", "\u2028", "\u2029");
-            var delimited_comment = new CommentTerminal("DelimitedComment", "/*", "*/");
-            NonGrammarTerminals.Add(single_line_comment);
-            NonGrammarTerminals.Add(delimited_comment);
-
-            var state = new KeyTerm("state", "state");
-            var init = new KeyTerm("init", "init");
-            var exit = new KeyTerm("exit", "exit");
-            var update = new KeyTerm("update", "update");
-            var start = new KeyTerm("start", "start");
-            var split = new KeyTerm("split", "split");
-            var reset = new KeyTerm("reset", "reset");
-            var startup = new KeyTerm("startup", "startup");
-            var shutdown = new KeyTerm("shutdown", "shutdown");
-            var isLoading = new KeyTerm("isLoading", "isLoading");
-            var gameTime = new KeyTerm("gameTime", "gameTime");
-            var onStart = new KeyTerm("onStart", "onStart");
-            var onSplit = new KeyTerm("onSplit", "onSplit");
-            var onReset = new KeyTerm("onReset", "onReset");
-            var comma = ToTerm(",", "comma");
-            var semi = ToTerm(";", "semi");
-
-            var root = new NonTerminal("root");
-            var state_def = new NonTerminal("stateDef");
-            var version = new NonTerminal("version");
-            var state_list = new NonTerminal("stateList");
-            var method_list = new NonTerminal("methodList");
-            var var_list = new NonTerminal("varList");
-            var var = new NonTerminal("var");
-            var module = new NonTerminal("module");
-            var method = new NonTerminal("method");
-            var offset_list = new NonTerminal("offsetList");
-            var offset = new NonTerminal("offset");
-            var method_type = new NonTerminal("methodType");
-
-            root.Rule = state_list + method_list;
-            version.Rule = (comma + string_lit) | Empty;
-            state_def.Rule = state + "(" + string_lit + version + ")" + "{" + var_list + "}";
-            state_list.Rule = MakeStarRule(state_list, state_def);
-            method_list.Rule = MakeStarRule(method_list, method);
-            var_list.Rule = MakeStarRule(var_list, semi, var);
-            module.Rule = (string_lit + comma) | Empty;
-            var.Rule = (identifier + identifier + ":" + module + offset_list) | Empty;
-            method.Rule = (method_type + "{" + code + "}") | Empty;
-            offset_list.Rule = MakePlusRule(offset_list, comma, offset);
-            offset.Rule = number;
-            method_type.Rule = init | exit | update | start | split | isLoading | gameTime | reset | startup | shutdown | onStart | onSplit | onReset;
-
-            Root = root;
-
-            MarkTransient(var_list, method_list, offset, method_type);
-
-            LanguageFlags = LanguageFlags.NewLineBeforeEOF;
+            token += cut;
+            remaining = remaining.Substring(index);
+            stack += cut.Count(x => x == '{');
+            stack--;
         }
 
-        private static Token MatchCodeTerminal(Terminal terminal, ParsingContext context, ISourceStream source)
-        {
-            var remaining = source.Text.Substring(source.Location.Position);
-            var stack = 1;
-            var token = "";
+        token = token.Substring(0, token.Length - 1);
+        source.PreviewPosition += token.Length;
 
-            while (stack > 0)
-            {
-                var index = remaining.IndexOf('}') + 1;
-                var cut = remaining.Substring(0, index);
-
-                token += cut;
-                remaining = remaining.Substring(index);
-                stack += cut.Count(x => x == '{');
-                stack--;
-            }
-
-            token = token.Substring(0, token.Length - 1);
-            source.PreviewPosition += token.Length;
-
-            return source.CreateToken(terminal.OutputTerminal);
-        }
+        return source.CreateToken(terminal.OutputTerminal);
     }
 }

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLGrammar.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLGrammar.cs
@@ -10,10 +10,10 @@ public class ASLGrammar : Grammar
     public ASLGrammar()
         : base(true)
     {
-        var string_lit = TerminalFactory.CreateCSharpString("string");
-        var number = TerminalFactory.CreateCSharpNumber("number");
+        StringLiteral string_lit = TerminalFactory.CreateCSharpString("string");
+        NumberLiteral number = TerminalFactory.CreateCSharpNumber("number");
         number.Options |= NumberOptions.AllowSign;
-        var identifier = TerminalFactory.CreateCSharpIdentifier("identifier");
+        IdentifierTerminal identifier = TerminalFactory.CreateCSharpIdentifier("identifier");
         var code = new CustomTerminal("code", MatchCodeTerminal);
 
         var single_line_comment = new CommentTerminal("SingleLineComment", "//", "\r", "\n", "\u2085", "\u2028", "\u2029");
@@ -35,8 +35,8 @@ public class ASLGrammar : Grammar
         var onStart = new KeyTerm("onStart", "onStart");
         var onSplit = new KeyTerm("onSplit", "onSplit");
         var onReset = new KeyTerm("onReset", "onReset");
-        var comma = ToTerm(",", "comma");
-        var semi = ToTerm(";", "semi");
+        KeyTerm comma = ToTerm(",", "comma");
+        KeyTerm semi = ToTerm(";", "semi");
 
         var root = new NonTerminal("root");
         var state_def = new NonTerminal("stateDef");
@@ -73,14 +73,14 @@ public class ASLGrammar : Grammar
 
     private static Token MatchCodeTerminal(Terminal terminal, ParsingContext context, ISourceStream source)
     {
-        var remaining = source.Text.Substring(source.Location.Position);
-        var stack = 1;
-        var token = "";
+        string remaining = source.Text.Substring(source.Location.Position);
+        int stack = 1;
+        string token = "";
 
         while (stack > 0)
         {
-            var index = remaining.IndexOf('}') + 1;
-            var cut = remaining.Substring(0, index);
+            int index = remaining.IndexOf('}') + 1;
+            string cut = remaining.Substring(0, index);
 
             token += cut;
             remaining = remaining.Substring(index);

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLGrammar.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLGrammar.cs
@@ -73,22 +73,22 @@ public class ASLGrammar : Grammar
 
     private static Token MatchCodeTerminal(Terminal terminal, ParsingContext context, ISourceStream source)
     {
-        string remaining = source.Text.Substring(source.Location.Position);
+        string remaining = source.Text[source.Location.Position..];
         int stack = 1;
         string token = "";
 
         while (stack > 0)
         {
             int index = remaining.IndexOf('}') + 1;
-            string cut = remaining.Substring(0, index);
+            string cut = remaining[..index];
 
             token += cut;
-            remaining = remaining.Substring(index);
+            remaining = remaining[index..];
             stack += cut.Count(x => x == '{');
             stack--;
         }
 
-        token = token.Substring(0, token.Length - 1);
+        token = token[..^1];
         source.PreviewPosition += token.Length;
 
         return source.CreateToken(terminal.OutputTerminal);

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLMethod.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLMethod.cs
@@ -22,7 +22,7 @@ public class ASLMethod
 
     public Module Module { get; }
 
-    private dynamic _compiled_code;
+    private readonly dynamic _compiled_code;
 
     public ASLMethod(string code, string name = null, int script_line = 0)
     {

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLMethod.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLMethod.cs
@@ -40,7 +40,7 @@ public class ASLMethod
         };
 
         using var provider = new Microsoft.CSharp.CSharpCodeProvider(options);
-        var user_code_start_marker = "// USER_CODE_START";
+        string user_code_start_marker = "// USER_CODE_START";
         string source = $@"
 using System;
 using System.Collections.Generic;
@@ -75,8 +75,8 @@ public class CompiledScript
 
         if (script_line > 0)
         {
-            var user_code_index = source.IndexOf(user_code_start_marker);
-            var compiled_code_line = source.Take(user_code_index).Count(c => c == '\n') + 2;
+            int user_code_index = source.IndexOf(user_code_start_marker);
+            int compiled_code_line = source.Take(user_code_index).Count(c => c == '\n') + 2;
             LineOffset = script_line - compiled_code_line;
         }
 
@@ -96,14 +96,14 @@ public class CompiledScript
         parameters.ReferencedAssemblies.Add("Microsoft.CSharp.dll");
         parameters.ReferencedAssemblies.Add("LiveSplit.Core.dll");
 
-        var res = provider.CompileAssemblyFromSource(parameters, source);
+        CompilerResults res = provider.CompileAssemblyFromSource(parameters, source);
         if (res.Errors.HasErrors)
         {
             throw new ASLCompilerException(this, res.Errors);
         }
 
         Module = res.CompiledAssembly.ManifestModule;
-        var type = res.CompiledAssembly.GetType("CompiledScript");
+        Type type = res.CompiledAssembly.GetType("CompiledScript");
         _compiled_code = Activator.CreateInstance(type);
     }
 

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLMethod.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLMethod.cs
@@ -27,7 +27,9 @@ public class ASLMethod
     public ASLMethod(string code, string name = null, int script_line = 0)
     {
         if (code == null)
+        {
             throw new ArgumentNullException(nameof(code));
+        }
 
         Name = name;
         IsEmpty = string.IsNullOrWhiteSpace(code);
@@ -97,7 +99,9 @@ public class CompiledScript
 
             var res = provider.CompileAssemblyFromSource(parameters, source);
             if (res.Errors.HasErrors)
+            {
                 throw new ASLCompilerException(this, res.Errors);
+            }
 
             Module = res.CompiledAssembly.ManifestModule;
             var type = res.CompiledAssembly.GetType("CompiledScript");
@@ -120,6 +124,7 @@ public class CompiledScript
         {
             throw new ASLRuntimeException(this, ex);
         }
+
         version = _compiled_code.version;
         refreshRate = _compiled_code.refreshRate;
         return ret;

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLMethod.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLMethod.cs
@@ -39,10 +39,9 @@ public class ASLMethod
             { "CompilerVersion", "v4.0" }
         };
 
-        using (var provider = new Microsoft.CSharp.CSharpCodeProvider(options))
-        {
-            var user_code_start_marker = "// USER_CODE_START";
-            string source = $@"
+        using var provider = new Microsoft.CSharp.CSharpCodeProvider(options);
+        var user_code_start_marker = "// USER_CODE_START";
+        string source = $@"
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -74,39 +73,38 @@ public class CompiledScript
     }}
 }}";
 
-            if (script_line > 0)
-            {
-                var user_code_index = source.IndexOf(user_code_start_marker);
-                var compiled_code_line = source.Take(user_code_index).Count(c => c == '\n') + 2;
-                LineOffset = script_line - compiled_code_line;
-            }
-
-            var parameters = new CompilerParameters()
-            {
-                GenerateInMemory = true,
-                CompilerOptions = "/optimize /d:TRACE /debug:pdbonly",
-            };
-            parameters.ReferencedAssemblies.Add("System.dll");
-            parameters.ReferencedAssemblies.Add("System.Core.dll");
-            parameters.ReferencedAssemblies.Add("System.Data.dll");
-            parameters.ReferencedAssemblies.Add("System.Data.DataSetExtensions.dll");
-            parameters.ReferencedAssemblies.Add("System.Drawing.dll");
-            parameters.ReferencedAssemblies.Add("System.Windows.Forms.dll");
-            parameters.ReferencedAssemblies.Add("System.Xml.dll");
-            parameters.ReferencedAssemblies.Add("System.Xml.Linq.dll");
-            parameters.ReferencedAssemblies.Add("Microsoft.CSharp.dll");
-            parameters.ReferencedAssemblies.Add("LiveSplit.Core.dll");
-
-            var res = provider.CompileAssemblyFromSource(parameters, source);
-            if (res.Errors.HasErrors)
-            {
-                throw new ASLCompilerException(this, res.Errors);
-            }
-
-            Module = res.CompiledAssembly.ManifestModule;
-            var type = res.CompiledAssembly.GetType("CompiledScript");
-            _compiled_code = Activator.CreateInstance(type);
+        if (script_line > 0)
+        {
+            var user_code_index = source.IndexOf(user_code_start_marker);
+            var compiled_code_line = source.Take(user_code_index).Count(c => c == '\n') + 2;
+            LineOffset = script_line - compiled_code_line;
         }
+
+        var parameters = new CompilerParameters()
+        {
+            GenerateInMemory = true,
+            CompilerOptions = "/optimize /d:TRACE /debug:pdbonly",
+        };
+        parameters.ReferencedAssemblies.Add("System.dll");
+        parameters.ReferencedAssemblies.Add("System.Core.dll");
+        parameters.ReferencedAssemblies.Add("System.Data.dll");
+        parameters.ReferencedAssemblies.Add("System.Data.DataSetExtensions.dll");
+        parameters.ReferencedAssemblies.Add("System.Drawing.dll");
+        parameters.ReferencedAssemblies.Add("System.Windows.Forms.dll");
+        parameters.ReferencedAssemblies.Add("System.Xml.dll");
+        parameters.ReferencedAssemblies.Add("System.Xml.Linq.dll");
+        parameters.ReferencedAssemblies.Add("Microsoft.CSharp.dll");
+        parameters.ReferencedAssemblies.Add("LiveSplit.Core.dll");
+
+        var res = provider.CompileAssemblyFromSource(parameters, source);
+        if (res.Errors.HasErrors)
+        {
+            throw new ASLCompilerException(this, res.Errors);
+        }
+
+        Module = res.CompiledAssembly.ManifestModule;
+        var type = res.CompiledAssembly.GetType("CompiledScript");
+        _compiled_code = Activator.CreateInstance(type);
     }
 
     public dynamic Call(LiveSplitState timer, ExpandoObject vars, ref string version, ref double refreshRate,

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLMethod.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLMethod.cs
@@ -1,5 +1,4 @@
-﻿using LiveSplit.Model;
-using System;
+﻿using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -7,39 +6,41 @@ using System.Dynamic;
 using System.Linq;
 using System.Reflection;
 
-namespace LiveSplit.ASL
+using LiveSplit.Model;
+
+namespace LiveSplit.ASL;
+
+public class ASLMethod
 {
-    public class ASLMethod
+    public ASLScript.Methods ScriptMethods { get; set; }
+
+    public string Name { get; }
+
+    public bool IsEmpty { get; }
+
+    public int LineOffset { get; }
+
+    public Module Module { get; }
+
+    private dynamic _compiled_code;
+
+    public ASLMethod(string code, string name = null, int script_line = 0)
     {
-        public ASLScript.Methods ScriptMethods { get; set; }
+        if (code == null)
+            throw new ArgumentNullException(nameof(code));
 
-        public string Name { get; }
+        Name = name;
+        IsEmpty = string.IsNullOrWhiteSpace(code);
+        code = code.Replace("return;", "return null;"); // hack
 
-        public bool IsEmpty { get; }
+        var options = new Dictionary<string, string> {
+            { "CompilerVersion", "v4.0" }
+        };
 
-        public int LineOffset { get; }
-
-        public Module Module { get; }
-
-        private dynamic _compiled_code;
-
-        public ASLMethod(string code, string name = null, int script_line = 0)
+        using (var provider = new Microsoft.CSharp.CSharpCodeProvider(options))
         {
-            if (code == null)
-                throw new ArgumentNullException(nameof(code));
-
-            Name = name;
-            IsEmpty = string.IsNullOrWhiteSpace(code);
-            code = code.Replace("return;", "return null;"); // hack
-
-            var options = new Dictionary<string, string> {
-                { "CompilerVersion", "v4.0" }
-            };
-
-            using (var provider = new Microsoft.CSharp.CSharpCodeProvider(options))
-            {
-                var user_code_start_marker = "// USER_CODE_START";
-                string source = $@"
+            var user_code_start_marker = "// USER_CODE_START";
+            string source = $@"
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -65,62 +66,62 @@ public class CompiledScript
     {{
         var memory = game;
         var modules = game != null ? game.ModulesWow64Safe() : null;
-        { user_code_start_marker }
-	    { code }
+        {user_code_start_marker}
+	    {code}
 	    return null;
     }}
 }}";
 
-                if (script_line > 0)
-                {
-                    var user_code_index = source.IndexOf(user_code_start_marker);
-                    var compiled_code_line = source.Take(user_code_index).Count(c => c == '\n') + 2;
-                    LineOffset = script_line - compiled_code_line;
-                }
-
-                var parameters = new CompilerParameters() {
-                    GenerateInMemory = true,
-                    CompilerOptions = "/optimize /d:TRACE /debug:pdbonly",
-                };
-                parameters.ReferencedAssemblies.Add("System.dll");
-                parameters.ReferencedAssemblies.Add("System.Core.dll");
-                parameters.ReferencedAssemblies.Add("System.Data.dll");
-                parameters.ReferencedAssemblies.Add("System.Data.DataSetExtensions.dll");
-                parameters.ReferencedAssemblies.Add("System.Drawing.dll");
-                parameters.ReferencedAssemblies.Add("System.Windows.Forms.dll");
-                parameters.ReferencedAssemblies.Add("System.Xml.dll");
-                parameters.ReferencedAssemblies.Add("System.Xml.Linq.dll");
-                parameters.ReferencedAssemblies.Add("Microsoft.CSharp.dll");
-                parameters.ReferencedAssemblies.Add("LiveSplit.Core.dll");
-
-                var res = provider.CompileAssemblyFromSource(parameters, source);
-                if (res.Errors.HasErrors)
-                    throw new ASLCompilerException(this, res.Errors);
-
-                Module = res.CompiledAssembly.ManifestModule;
-                var type = res.CompiledAssembly.GetType("CompiledScript");
-                _compiled_code = Activator.CreateInstance(type);
+            if (script_line > 0)
+            {
+                var user_code_index = source.IndexOf(user_code_start_marker);
+                var compiled_code_line = source.Take(user_code_index).Count(c => c == '\n') + 2;
+                LineOffset = script_line - compiled_code_line;
             }
-        }
 
-        public dynamic Call(LiveSplitState timer, ExpandoObject vars, ref string version, ref double refreshRate,
-            dynamic settings, ExpandoObject old = null, ExpandoObject current = null, Process game = null)
+            var parameters = new CompilerParameters()
+            {
+                GenerateInMemory = true,
+                CompilerOptions = "/optimize /d:TRACE /debug:pdbonly",
+            };
+            parameters.ReferencedAssemblies.Add("System.dll");
+            parameters.ReferencedAssemblies.Add("System.Core.dll");
+            parameters.ReferencedAssemblies.Add("System.Data.dll");
+            parameters.ReferencedAssemblies.Add("System.Data.DataSetExtensions.dll");
+            parameters.ReferencedAssemblies.Add("System.Drawing.dll");
+            parameters.ReferencedAssemblies.Add("System.Windows.Forms.dll");
+            parameters.ReferencedAssemblies.Add("System.Xml.dll");
+            parameters.ReferencedAssemblies.Add("System.Xml.Linq.dll");
+            parameters.ReferencedAssemblies.Add("Microsoft.CSharp.dll");
+            parameters.ReferencedAssemblies.Add("LiveSplit.Core.dll");
+
+            var res = provider.CompileAssemblyFromSource(parameters, source);
+            if (res.Errors.HasErrors)
+                throw new ASLCompilerException(this, res.Errors);
+
+            Module = res.CompiledAssembly.ManifestModule;
+            var type = res.CompiledAssembly.GetType("CompiledScript");
+            _compiled_code = Activator.CreateInstance(type);
+        }
+    }
+
+    public dynamic Call(LiveSplitState timer, ExpandoObject vars, ref string version, ref double refreshRate,
+        dynamic settings, ExpandoObject old = null, ExpandoObject current = null, Process game = null)
+    {
+        // dynamic args can't be ref or out, this is a workaround
+        _compiled_code.version = version;
+        _compiled_code.refreshRate = refreshRate;
+        dynamic ret;
+        try
         {
-            // dynamic args can't be ref or out, this is a workaround
-            _compiled_code.version = version;
-            _compiled_code.refreshRate = refreshRate;
-            dynamic ret;
-            try
-            {
-                ret = _compiled_code.Execute(timer, old, current, vars, game, settings);
-            }
-            catch (Exception ex)
-            {
-                throw new ASLRuntimeException(this, ex);
-            }
-            version = _compiled_code.version;
-            refreshRate = _compiled_code.refreshRate;
-            return ret;
+            ret = _compiled_code.Execute(timer, old, current, vars, game, settings);
         }
+        catch (Exception ex)
+        {
+            throw new ASLRuntimeException(this, ex);
+        }
+        version = _compiled_code.version;
+        refreshRate = _compiled_code.refreshRate;
+        return ret;
     }
 }

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLParser.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLParser.cs
@@ -66,7 +66,10 @@ public class ASLParser
 
             state.GameVersion = version;
             if (!states.ContainsKey(process_name))
+            {
                 states.Add(process_name, new List<ASLState>());
+            }
+
             states[process_name].Add(state);
         }
 

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLParser.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLParser.cs
@@ -67,7 +67,7 @@ public class ASLParser
             state.GameVersion = version;
             if (!states.ContainsKey(process_name))
             {
-                states.Add(process_name, new List<ASLState>());
+                states.Add(process_name, []);
             }
 
             states[process_name].Add(state);

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLParser.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLParser.cs
@@ -1,103 +1,104 @@
-﻿using Irony.Parsing;
-using LiveSplit.ComponentUtil;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace LiveSplit.ASL
+using Irony.Parsing;
+
+using LiveSplit.ComponentUtil;
+
+namespace LiveSplit.ASL;
+
+public class ASLParser
 {
-    public class ASLParser
+    public static ASLScript Parse(string code)
     {
-        public static ASLScript Parse(string code)
+        var grammar = new ASLGrammar();
+        var parser = new Parser(grammar);
+        var tree = parser.Parse(code);
+
+        if (tree.HasErrors())
         {
-            var grammar = new ASLGrammar();
-            var parser = new Parser(grammar);
-            var tree = parser.Parse(code);
-
-            if (tree.HasErrors())
+            var error_msg = new StringBuilder("ASL parse error(s):");
+            foreach (var msg in parser.Context.CurrentParseTree.ParserMessages)
             {
-                var error_msg = new StringBuilder("ASL parse error(s):");
-                foreach (var msg in parser.Context.CurrentParseTree.ParserMessages)
-                {
-                    var loc = msg.Location;
-                    error_msg.Append($"\nat Line {loc.Line + 1}, Col {loc.Column + 1}: {msg.Message}");
-                }
-
-                throw new Exception(error_msg.ToString());
+                var loc = msg.Location;
+                error_msg.Append($"\nat Line {loc.Line + 1}, Col {loc.Column + 1}: {msg.Message}");
             }
 
-            var root_childs = tree.Root.ChildNodes;
-            var methods_node = root_childs.First(x => x.Term.Name == "methodList");
-            var states_node = root_childs.First(x => x.Term.Name == "stateList");
-
-            var states = new Dictionary<string, List<ASLState>>();
-
-            foreach (var state_node in states_node.ChildNodes)
-            {
-                var process_name = (string)state_node.ChildNodes[2].Token.Value;
-                var version =
-                    state_node.ChildNodes[3].ChildNodes.Skip(1).Select(x => (string)x.Token.Value).FirstOrDefault() ??
-                    string.Empty;
-                var value_definition_nodes = state_node.ChildNodes[6].ChildNodes;
-
-                var state = new ASLState();
-
-                foreach (var value_definition_node in value_definition_nodes.Where(x => x.ChildNodes.Count > 0))
-                {
-                    var child_nodes = value_definition_node.ChildNodes;
-                    var type = (string)child_nodes[0].Token.Value;
-                    var identifier = (string)child_nodes[1].Token.Value;
-                    var module =
-                        child_nodes[3].ChildNodes.Take(1).Select(x => (string)x.Token.Value).FirstOrDefault() ??
-                        string.Empty;
-                    var module_base = child_nodes[4].ChildNodes.Select(x => (int)x.Token.Value).First();
-                    var offsets = child_nodes[4].ChildNodes.Skip(1).Select(x => (int)x.Token.Value).ToArray();
-                    var value_definition = new ASLValueDefinition()
-                    {
-                        Identifier = identifier,
-                        Type = type,
-                        Pointer = new DeepPointer(module, module_base, offsets)
-                    };
-                    state.ValueDefinitions.Add(value_definition);
-                }
-
-                state.GameVersion = version;
-                if (!states.ContainsKey(process_name))
-                    states.Add(process_name, new List<ASLState>());
-                states[process_name].Add(state);
-            }
-
-            var methods = new ASLScript.Methods();
-
-            foreach (var method in methods_node.ChildNodes[0].ChildNodes)
-            {
-                var body = (string)method.ChildNodes[2].Token.Value;
-                var method_name = (string)method.ChildNodes[0].Token.Value;
-                var line = method.ChildNodes[2].Token.Location.Line + 1;
-                var script = new ASLMethod(body, method_name, line)
-                {
-                    ScriptMethods = methods
-                };
-                switch (method_name)
-                {
-                    case "init": methods.init = script; break;
-                    case "exit": methods.exit = script; break;
-                    case "update": methods.update = script; break;
-                    case "start": methods.start = script; break;
-                    case "split": methods.split = script; break;
-                    case "isLoading": methods.isLoading = script; break;
-                    case "gameTime": methods.gameTime = script; break;
-                    case "reset": methods.reset = script; break;
-                    case "startup": methods.startup = script; break;
-                    case "shutdown": methods.shutdown = script; break;
-                    case "onStart": methods.onStart = script; break;
-                    case "onSplit": methods.onSplit = script; break;
-                    case "onReset": methods.onReset = script; break;
-                }
-            }
-
-            return new ASLScript(methods, states);
+            throw new Exception(error_msg.ToString());
         }
+
+        var root_childs = tree.Root.ChildNodes;
+        var methods_node = root_childs.First(x => x.Term.Name == "methodList");
+        var states_node = root_childs.First(x => x.Term.Name == "stateList");
+
+        var states = new Dictionary<string, List<ASLState>>();
+
+        foreach (var state_node in states_node.ChildNodes)
+        {
+            var process_name = (string)state_node.ChildNodes[2].Token.Value;
+            var version =
+                state_node.ChildNodes[3].ChildNodes.Skip(1).Select(x => (string)x.Token.Value).FirstOrDefault() ??
+                string.Empty;
+            var value_definition_nodes = state_node.ChildNodes[6].ChildNodes;
+
+            var state = new ASLState();
+
+            foreach (var value_definition_node in value_definition_nodes.Where(x => x.ChildNodes.Count > 0))
+            {
+                var child_nodes = value_definition_node.ChildNodes;
+                var type = (string)child_nodes[0].Token.Value;
+                var identifier = (string)child_nodes[1].Token.Value;
+                var module =
+                    child_nodes[3].ChildNodes.Take(1).Select(x => (string)x.Token.Value).FirstOrDefault() ??
+                    string.Empty;
+                var module_base = child_nodes[4].ChildNodes.Select(x => (int)x.Token.Value).First();
+                var offsets = child_nodes[4].ChildNodes.Skip(1).Select(x => (int)x.Token.Value).ToArray();
+                var value_definition = new ASLValueDefinition()
+                {
+                    Identifier = identifier,
+                    Type = type,
+                    Pointer = new DeepPointer(module, module_base, offsets)
+                };
+                state.ValueDefinitions.Add(value_definition);
+            }
+
+            state.GameVersion = version;
+            if (!states.ContainsKey(process_name))
+                states.Add(process_name, new List<ASLState>());
+            states[process_name].Add(state);
+        }
+
+        var methods = new ASLScript.Methods();
+
+        foreach (var method in methods_node.ChildNodes[0].ChildNodes)
+        {
+            var body = (string)method.ChildNodes[2].Token.Value;
+            var method_name = (string)method.ChildNodes[0].Token.Value;
+            var line = method.ChildNodes[2].Token.Location.Line + 1;
+            var script = new ASLMethod(body, method_name, line)
+            {
+                ScriptMethods = methods
+            };
+            switch (method_name)
+            {
+                case "init": methods.init = script; break;
+                case "exit": methods.exit = script; break;
+                case "update": methods.update = script; break;
+                case "start": methods.start = script; break;
+                case "split": methods.split = script; break;
+                case "isLoading": methods.isLoading = script; break;
+                case "gameTime": methods.gameTime = script; break;
+                case "reset": methods.reset = script; break;
+                case "startup": methods.startup = script; break;
+                case "shutdown": methods.shutdown = script; break;
+                case "onStart": methods.onStart = script; break;
+                case "onSplit": methods.onSplit = script; break;
+                case "onReset": methods.onReset = script; break;
+            }
+        }
+
+        return new ASLScript(methods, states);
     }
 }

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLScript.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLScript.cs
@@ -395,8 +395,8 @@ public class ASLScript
 
     private void Debug(string output, params object[] args)
     {
-        Log.Info(String.Format("[ASL/{1}] {0}",
-            String.Format(output, args),
+        Log.Info(string.Format("[ASL/{1}] {0}",
+            string.Format(output, args),
             this.GetHashCode()));
     }
 }

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLScript.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLScript.cs
@@ -321,7 +321,7 @@ public class ASLScript
             return;
         }
 
-        if (state.CurrentPhase == TimerPhase.Running || state.CurrentPhase == TimerPhase.Paused)
+        if (state.CurrentPhase is TimerPhase.Running or TimerPhase.Paused)
         {
             if (_uses_game_time && !state.IsGameTimeInitialized)
             {

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLScript.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLScript.cs
@@ -14,7 +14,7 @@ public class ASLScript
 {
     public class Methods : IEnumerable<ASLMethod>
     {
-        private static ASLMethod no_op = new ASLMethod("");
+        private static readonly ASLMethod no_op = new ASLMethod("");
 
         public ASLMethod startup = no_op;
         public ASLMethod shutdown = no_op;
@@ -86,17 +86,17 @@ public class ASLScript
     public ASLState OldState { get; private set; }
     public ExpandoObject Vars { get; }
 
-    private bool _uses_game_time;
+    private readonly bool _uses_game_time;
     private bool _init_completed;
 
-    private ASLSettings _settings;
+    private readonly ASLSettings _settings;
 
     private Process _game;
     private TimerModel _timer;
 
-    private Dictionary<string, List<ASLState>> _states;
+    private readonly Dictionary<string, List<ASLState>> _states;
 
-    private Methods _methods;
+    private readonly Methods _methods;
 
     public ASLScript(Methods methods, Dictionary<string, List<ASLState>> states)
     {

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLScript.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLScript.cs
@@ -50,8 +50,15 @@ public class ASLScript
             };
         }
 
-        public IEnumerator<ASLMethod> GetEnumerator() => ((IEnumerable<ASLMethod>)GetMethods()).GetEnumerator();
-        IEnumerator IEnumerable.GetEnumerator() => GetMethods().GetEnumerator();
+        public IEnumerator<ASLMethod> GetEnumerator()
+        {
+            return ((IEnumerable<ASLMethod>)GetMethods()).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetMethods().GetEnumerator();
+        }
     }
 
     public event EventHandler<double> RefreshRateChanged;
@@ -60,7 +67,7 @@ public class ASLScript
     private string _game_version = string.Empty;
     public string GameVersion
     {
-        get { return _game_version; }
+        get => _game_version;
         set
         {
             if (value != _game_version)
@@ -72,7 +79,7 @@ public class ASLScript
     private double _refresh_rate = 1000 / 15d;
     public double RefreshRate // per sec
     {
-        get { return _refresh_rate; }
+        get => _refresh_rate;
         set
         {
             if (Math.Abs(value - _refresh_rate) > 0.01)
@@ -154,9 +161,20 @@ public class ASLScript
         return _settings;
     }
 
-    private void RunOnStart(object sender, EventArgs e) => RunMethod(_methods.onStart, (LiveSplitState)sender);
-    private void RunOnSplit(object sender, EventArgs e) => RunMethod(_methods.onSplit, (LiveSplitState)sender);
-    private void RunOnReset(object sender, TimerPhase e) => RunMethod(_methods.onReset, (LiveSplitState)sender);
+    private void RunOnStart(object sender, EventArgs e)
+    {
+        RunMethod(_methods.onStart, (LiveSplitState)sender);
+    }
+
+    private void RunOnSplit(object sender, EventArgs e)
+    {
+        RunMethod(_methods.onSplit, (LiveSplitState)sender);
+    }
+
+    private void RunOnReset(object sender, TimerPhase e)
+    {
+        RunMethod(_methods.onReset, (LiveSplitState)sender);
+    }
 
     public void RunShutdown(LiveSplitState state)
     {

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLScript.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLScript.cs
@@ -397,6 +397,6 @@ public class ASLScript
     {
         Log.Info(string.Format("[ASL/{1}] {0}",
             string.Format(output, args),
-            this.GetHashCode()));
+            GetHashCode()));
     }
 }

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLScript.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLScript.cs
@@ -32,8 +32,8 @@ public class ASLScript
 
         public ASLMethod[] GetMethods()
         {
-            return new ASLMethod[]
-            {
+            return
+            [
                 startup,
                 shutdown,
                 init,
@@ -47,7 +47,7 @@ public class ASLScript
                 onStart,
                 onSplit,
                 onReset
-            };
+            ];
         }
 
         public IEnumerator<ASLMethod> GetEnumerator()

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLScript.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLScript.cs
@@ -14,7 +14,7 @@ public class ASLScript
 {
     public class Methods : IEnumerable<ASLMethod>
     {
-        private static readonly ASLMethod no_op = new ASLMethod("");
+        private static readonly ASLMethod no_op = new("");
 
         public ASLMethod startup = no_op;
         public ASLMethod shutdown = no_op;
@@ -270,14 +270,14 @@ public class ASLScript
         GameVersion = string.Empty;
 
         // Fetch version from init-method
-        var ver = string.Empty;
+        string ver = string.Empty;
         RunMethod(_methods.init, state, ref ver);
 
         if (ver != GameVersion)
         {
             GameVersion = ver;
 
-            var version_state = _states.Where(kv => kv.Key.ToLower() == _game.ProcessName.ToLower())
+            ASLState version_state = _states.Where(kv => kv.Key.ToLower() == _game.ProcessName.ToLower())
                 .Select(kv => kv.Value)
                 .First() // states
                 .FirstOrDefault(s => s.GameVersion == ver);
@@ -328,13 +328,13 @@ public class ASLScript
                 _timer.InitializeGameTime();
             }
 
-            var is_paused = RunMethod(_methods.isLoading, state);
+            dynamic is_paused = RunMethod(_methods.isLoading, state);
             if (is_paused != null)
             {
                 state.IsGameTimePaused = is_paused;
             }
 
-            var game_time = RunMethod(_methods.gameTime, state);
+            dynamic game_time = RunMethod(_methods.gameTime, state);
             if (game_time != null)
             {
                 state.SetGameTime(game_time);
@@ -370,8 +370,8 @@ public class ASLScript
 
     private dynamic RunMethod(ASLMethod method, LiveSplitState state, ref string version)
     {
-        var refresh_rate = RefreshRate;
-        var result = method.Call(state, Vars, ref version, ref refresh_rate, _settings.Reader,
+        double refresh_rate = RefreshRate;
+        dynamic result = method.Call(state, Vars, ref version, ref refresh_rate, _settings.Reader,
             OldState?.Data, State?.Data, _game);
         RefreshRate = refresh_rate;
         return result;
@@ -379,15 +379,15 @@ public class ASLScript
 
     private dynamic RunMethod(ASLMethod method, LiveSplitState state)
     {
-        var version = GameVersion;
+        string version = GameVersion;
         return RunMethod(method, state, ref version);
     }
 
     // Run method without counting on being connected to the game (startup/shutdown).
     private void RunNoProcessMethod(ASLMethod method, LiveSplitState state, bool is_startup = false)
     {
-        var refresh_rate = RefreshRate;
-        var version = GameVersion;
+        double refresh_rate = RefreshRate;
+        string version = GameVersion;
         method.Call(state, Vars, ref version, ref refresh_rate,
             is_startup ? _settings.Builder : (object)_settings.Reader);
         RefreshRate = refresh_rate;

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLScript.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLScript.cs
@@ -71,7 +71,10 @@ public class ASLScript
         set
         {
             if (value != _game_version)
+            {
                 GameVersionChanged?.Invoke(this, value);
+            }
+
             _game_version = value;
         }
     }
@@ -83,7 +86,10 @@ public class ASLScript
         set
         {
             if (Math.Abs(value - _refresh_rate) > 0.01)
+            {
                 RefreshRateChanged?.Invoke(this, value);
+            }
+
             _refresh_rate = value;
         }
     }
@@ -114,11 +120,19 @@ public class ASLScript
         Vars = new ExpandoObject();
 
         if (!_methods.start.IsEmpty)
+        {
             _settings.AddBasicSetting("start");
+        }
+
         if (!_methods.split.IsEmpty)
+        {
             _settings.AddBasicSetting("split");
+        }
+
         if (!_methods.reset.IsEmpty)
+        {
             _settings.AddBasicSetting("reset");
+        }
 
         _uses_game_time = !_methods.isLoading.IsEmpty || !_methods.gameTime.IsEmpty;
     }
@@ -129,7 +143,10 @@ public class ASLScript
         if (_game == null)
         {
             if (_timer == null)
+            {
                 _timer = new TimerModel() { CurrentState = state };
+            }
+
             TryConnect(state);
         }
         else if (_game.HasExited)
@@ -139,9 +156,13 @@ public class ASLScript
         else
         {
             if (!_init_completed)
+            {
                 DoInit(state);
+            }
             else
+            {
                 DoUpdate(state);
+            }
         }
     }
 
@@ -152,11 +173,19 @@ public class ASLScript
         RunNoProcessMethod(_methods.startup, state, true);
 
         if (!_methods.onStart.IsEmpty)
+        {
             state.OnStart += RunOnStart;
+        }
+
         if (!_methods.onSplit.IsEmpty)
+        {
             state.OnSplit += RunOnSplit;
+        }
+
         if (!_methods.onReset.IsEmpty)
+        {
             state.OnReset += RunOnReset;
+        }
 
         return _settings;
     }
@@ -181,11 +210,19 @@ public class ASLScript
         Debug("Running shutdown");
 
         if (!_methods.onStart.IsEmpty)
+        {
             state.OnStart -= RunOnStart;
+        }
+
         if (!_methods.onSplit.IsEmpty)
+        {
             state.OnSplit -= RunOnSplit;
+        }
+
         if (!_methods.onReset.IsEmpty)
+        {
             state.OnReset -= RunOnReset;
+        }
 
         RunMethod(_methods.shutdown, state);
     }
@@ -203,7 +240,9 @@ public class ASLScript
         }).FirstOrDefault(x => x.Process != null);
 
         if (state_process == null)
+        {
             return;
+        }
 
         _init_completed = false;
         _game = state_process.Process;
@@ -288,25 +327,35 @@ public class ASLScript
         if (state.CurrentPhase == TimerPhase.Running || state.CurrentPhase == TimerPhase.Paused)
         {
             if (_uses_game_time && !state.IsGameTimeInitialized)
+            {
                 _timer.InitializeGameTime();
+            }
 
             var is_paused = RunMethod(_methods.isLoading, state);
             if (is_paused != null)
+            {
                 state.IsGameTimePaused = is_paused;
+            }
 
             var game_time = RunMethod(_methods.gameTime, state);
             if (game_time != null)
+            {
                 state.SetGameTime(game_time);
+            }
 
             if (RunMethod(_methods.reset, state) ?? false)
             {
                 if (_settings.GetBasicSettingValue("reset"))
+                {
                     _timer.Reset();
+                }
             }
             else if (RunMethod(_methods.split, state) ?? false)
             {
                 if (_settings.GetBasicSettingValue("split"))
+                {
                     _timer.Split();
+                }
             }
         }
 
@@ -315,7 +364,9 @@ public class ASLScript
             if (RunMethod(_methods.start, state) ?? false)
             {
                 if (_settings.GetBasicSettingValue("start"))
+                {
                     _timer.Start();
+                }
             }
         }
     }

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLScript.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLScript.cs
@@ -4,332 +4,333 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Dynamic;
 using System.Linq;
+
 using LiveSplit.Model;
 using LiveSplit.Options;
 
-namespace LiveSplit.ASL
+namespace LiveSplit.ASL;
+
+public class ASLScript
 {
-    public class ASLScript
+    public class Methods : IEnumerable<ASLMethod>
     {
-        public class Methods : IEnumerable<ASLMethod>
+        private static ASLMethod no_op = new ASLMethod("");
+
+        public ASLMethod startup = no_op;
+        public ASLMethod shutdown = no_op;
+        public ASLMethod init = no_op;
+        public ASLMethod exit = no_op;
+        public ASLMethod update = no_op;
+        public ASLMethod start = no_op;
+        public ASLMethod split = no_op;
+        public ASLMethod reset = no_op;
+        public ASLMethod isLoading = no_op;
+        public ASLMethod gameTime = no_op;
+        public ASLMethod onStart = no_op;
+        public ASLMethod onSplit = no_op;
+        public ASLMethod onReset = no_op;
+
+        public ASLMethod[] GetMethods()
         {
-            private static ASLMethod no_op = new ASLMethod("");
-
-            public ASLMethod startup = no_op;
-            public ASLMethod shutdown = no_op;
-            public ASLMethod init = no_op;
-            public ASLMethod exit = no_op;
-            public ASLMethod update = no_op;
-            public ASLMethod start = no_op;
-            public ASLMethod split = no_op;
-            public ASLMethod reset = no_op;
-            public ASLMethod isLoading = no_op;
-            public ASLMethod gameTime = no_op;
-            public ASLMethod onStart = no_op;
-            public ASLMethod onSplit = no_op;
-            public ASLMethod onReset = no_op;
-
-            public ASLMethod[] GetMethods()
+            return new ASLMethod[]
             {
-                return new ASLMethod[]
+                startup,
+                shutdown,
+                init,
+                exit,
+                update,
+                start,
+                split,
+                reset,
+                isLoading,
+                gameTime,
+                onStart,
+                onSplit,
+                onReset
+            };
+        }
+
+        public IEnumerator<ASLMethod> GetEnumerator() => ((IEnumerable<ASLMethod>)GetMethods()).GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetMethods().GetEnumerator();
+    }
+
+    public event EventHandler<double> RefreshRateChanged;
+    public event EventHandler<string> GameVersionChanged;
+
+    private string _game_version = string.Empty;
+    public string GameVersion
+    {
+        get { return _game_version; }
+        set
+        {
+            if (value != _game_version)
+                GameVersionChanged?.Invoke(this, value);
+            _game_version = value;
+        }
+    }
+
+    private double _refresh_rate = 1000 / 15d;
+    public double RefreshRate // per sec
+    {
+        get { return _refresh_rate; }
+        set
+        {
+            if (Math.Abs(value - _refresh_rate) > 0.01)
+                RefreshRateChanged?.Invoke(this, value);
+            _refresh_rate = value;
+        }
+    }
+
+    // public so other components (ASLVarViewer) can access
+    public ASLState State { get; private set; }
+    public ASLState OldState { get; private set; }
+    public ExpandoObject Vars { get; }
+
+    private bool _uses_game_time;
+    private bool _init_completed;
+
+    private ASLSettings _settings;
+
+    private Process _game;
+    private TimerModel _timer;
+
+    private Dictionary<string, List<ASLState>> _states;
+
+    private Methods _methods;
+
+    public ASLScript(Methods methods, Dictionary<string, List<ASLState>> states)
+    {
+        _methods = methods;
+        _states = states;
+
+        _settings = new ASLSettings();
+        Vars = new ExpandoObject();
+
+        if (!_methods.start.IsEmpty)
+            _settings.AddBasicSetting("start");
+        if (!_methods.split.IsEmpty)
+            _settings.AddBasicSetting("split");
+        if (!_methods.reset.IsEmpty)
+            _settings.AddBasicSetting("reset");
+
+        _uses_game_time = !_methods.isLoading.IsEmpty || !_methods.gameTime.IsEmpty;
+    }
+
+    // Update the script
+    public void Update(LiveSplitState state)
+    {
+        if (_game == null)
+        {
+            if (_timer == null)
+                _timer = new TimerModel() { CurrentState = state };
+            TryConnect(state);
+        }
+        else if (_game.HasExited)
+        {
+            DoExit(state);
+        }
+        else
+        {
+            if (!_init_completed)
+                DoInit(state);
+            else
+                DoUpdate(state);
+        }
+    }
+
+    // Run startup and return settings defined in ASL script.
+    public ASLSettings RunStartup(LiveSplitState state)
+    {
+        Debug("Running startup");
+        RunNoProcessMethod(_methods.startup, state, true);
+
+        if (!_methods.onStart.IsEmpty)
+            state.OnStart += RunOnStart;
+        if (!_methods.onSplit.IsEmpty)
+            state.OnSplit += RunOnSplit;
+        if (!_methods.onReset.IsEmpty)
+            state.OnReset += RunOnReset;
+
+        return _settings;
+    }
+
+    private void RunOnStart(object sender, EventArgs e) => RunMethod(_methods.onStart, (LiveSplitState)sender);
+    private void RunOnSplit(object sender, EventArgs e) => RunMethod(_methods.onSplit, (LiveSplitState)sender);
+    private void RunOnReset(object sender, TimerPhase e) => RunMethod(_methods.onReset, (LiveSplitState)sender);
+
+    public void RunShutdown(LiveSplitState state)
+    {
+        Debug("Running shutdown");
+
+        if (!_methods.onStart.IsEmpty)
+            state.OnStart -= RunOnStart;
+        if (!_methods.onSplit.IsEmpty)
+            state.OnSplit -= RunOnSplit;
+        if (!_methods.onReset.IsEmpty)
+            state.OnReset -= RunOnReset;
+
+        RunMethod(_methods.shutdown, state);
+    }
+
+    private void TryConnect(LiveSplitState state)
+    {
+        _game = null;
+
+        var state_process = _states.Keys.Select(proccessName => new
+        {
+            // default to the state with no version specified, if it exists
+            State = _states[proccessName].FirstOrDefault(s => s.GameVersion == "") ?? _states[proccessName].First(),
+            Process = Process.GetProcessesByName(proccessName).OrderByDescending(x => x.StartTime)
+                .FirstOrDefault(x => !x.HasExited)
+        }).FirstOrDefault(x => x.Process != null);
+
+        if (state_process == null)
+            return;
+
+        _init_completed = false;
+        _game = state_process.Process;
+        State = state_process.State;
+
+        if (State.GameVersion == "")
+        {
+            Debug("Connected to game: {0} (using default state descriptor)", _game.ProcessName);
+        }
+        else
+        {
+            Debug("Connected to game: {0} (state descriptor for version '{1}' chosen as default)",
+                _game.ProcessName,
+                State.GameVersion);
+        }
+
+        DoInit(state);
+    }
+
+    // This is executed each time after connecting to the game (usually just once,
+    // unless an error occurs before the method finishes).
+    private void DoInit(LiveSplitState state)
+    {
+        Debug("Initializing");
+
+        State.RefreshValues(_game);
+        OldState = State;
+        GameVersion = string.Empty;
+
+        // Fetch version from init-method
+        var ver = string.Empty;
+        RunMethod(_methods.init, state, ref ver);
+
+        if (ver != GameVersion)
+        {
+            GameVersion = ver;
+
+            var version_state = _states.Where(kv => kv.Key.ToLower() == _game.ProcessName.ToLower())
+                .Select(kv => kv.Value)
+                .First() // states
+                .FirstOrDefault(s => s.GameVersion == ver);
+
+            if (version_state != null)
+            {
+                // This state descriptor may already be selected
+                if (version_state != State)
                 {
-                    startup,
-                    shutdown,
-                    init,
-                    exit,
-                    update,
-                    start,
-                    split,
-                    reset,
-                    isLoading,
-                    gameTime,
-                    onStart,
-                    onSplit,
-                    onReset
-                };
-            }
-
-            public IEnumerator<ASLMethod> GetEnumerator() => ((IEnumerable<ASLMethod>)GetMethods()).GetEnumerator();
-            IEnumerator IEnumerable.GetEnumerator() => GetMethods().GetEnumerator();
-        }
-
-        public event EventHandler<double> RefreshRateChanged;
-        public event EventHandler<string> GameVersionChanged;
-
-        private string _game_version = string.Empty;
-        public string GameVersion
-        {
-            get { return _game_version; }
-            set
-            {
-                if (value != _game_version)
-                    GameVersionChanged?.Invoke(this, value);
-                _game_version = value;
-            }
-        }
-
-        private double _refresh_rate = 1000 / 15d;
-        public double RefreshRate // per sec
-        {
-            get { return _refresh_rate; }
-            set
-            {
-                if (Math.Abs(value - _refresh_rate) > 0.01)
-                    RefreshRateChanged?.Invoke(this, value);
-                _refresh_rate = value;
-            }
-        }
-
-        // public so other components (ASLVarViewer) can access
-        public ASLState State { get; private set; }
-        public ASLState OldState { get; private set; }
-        public ExpandoObject Vars { get; }
-
-        private bool _uses_game_time;
-        private bool _init_completed;
-
-        private ASLSettings _settings;
-
-        private Process _game;
-        private TimerModel _timer;
-
-        private Dictionary<string, List<ASLState>> _states;
-
-        private Methods _methods;
-
-        public ASLScript(Methods methods, Dictionary<string, List<ASLState>> states)
-        {
-            _methods = methods;
-            _states = states;
-
-            _settings = new ASLSettings();
-            Vars = new ExpandoObject();
-
-            if (!_methods.start.IsEmpty)
-                _settings.AddBasicSetting("start");
-            if (!_methods.split.IsEmpty)
-                _settings.AddBasicSetting("split");
-            if (!_methods.reset.IsEmpty)
-                _settings.AddBasicSetting("reset");
-
-            _uses_game_time = !_methods.isLoading.IsEmpty || !_methods.gameTime.IsEmpty;
-        }
-
-        // Update the script
-        public void Update(LiveSplitState state)
-        {
-            if (_game == null)
-            {
-                if (_timer == null)
-                    _timer = new TimerModel() { CurrentState = state };
-                TryConnect(state);
-            }
-            else if (_game.HasExited)
-            {
-                DoExit(state);
+                    State = version_state;
+                    State.RefreshValues(_game);
+                    OldState = State;
+                    Debug($"Switched to state descriptor for version '{GameVersion}'");
+                }
             }
             else
             {
-                if (!_init_completed)
-                    DoInit(state);
-                else
-                    DoUpdate(state);
+                Debug($"No state descriptor for version '{GameVersion}' (will keep using default one)");
             }
         }
 
-        // Run startup and return settings defined in ASL script.
-        public ASLSettings RunStartup(LiveSplitState state)
+        _init_completed = true;
+        Debug("Init completed, running main methods");
+    }
+
+    private void DoExit(LiveSplitState state)
+    {
+        Debug("Running exit");
+        _game = null;
+        RunNoProcessMethod(_methods.exit, state);
+    }
+
+    // This is executed repeatedly as long as the game is connected and initialized.
+    private void DoUpdate(LiveSplitState state)
+    {
+        OldState = State.RefreshValues(_game);
+
+        if (!(RunMethod(_methods.update, state) ?? true))
         {
-            Debug("Running startup");
-            RunNoProcessMethod(_methods.startup, state, true);
-
-            if(!_methods.onStart.IsEmpty)
-                state.OnStart += RunOnStart;
-            if(!_methods.onSplit.IsEmpty)
-                state.OnSplit += RunOnSplit;
-            if(!_methods.onReset.IsEmpty)
-                state.OnReset += RunOnReset;
-
-            return _settings;
+            // If Update explicitly returns false, don't run anything else
+            return;
         }
 
-        private void RunOnStart(object sender, EventArgs e) => RunMethod(_methods.onStart, (LiveSplitState)sender);
-        private void RunOnSplit(object sender, EventArgs e) => RunMethod(_methods.onSplit, (LiveSplitState)sender);
-        private void RunOnReset(object sender, TimerPhase e) => RunMethod(_methods.onReset, (LiveSplitState)sender);
-
-        public void RunShutdown(LiveSplitState state)
+        if (state.CurrentPhase == TimerPhase.Running || state.CurrentPhase == TimerPhase.Paused)
         {
-            Debug("Running shutdown");
+            if (_uses_game_time && !state.IsGameTimeInitialized)
+                _timer.InitializeGameTime();
 
-            if(!_methods.onStart.IsEmpty)
-                state.OnStart -= RunOnStart;
-            if(!_methods.onSplit.IsEmpty)
-                state.OnSplit -= RunOnSplit;
-            if(!_methods.onReset.IsEmpty)
-                state.OnReset -= RunOnReset;
+            var is_paused = RunMethod(_methods.isLoading, state);
+            if (is_paused != null)
+                state.IsGameTimePaused = is_paused;
 
-            RunMethod(_methods.shutdown, state);
-        }
+            var game_time = RunMethod(_methods.gameTime, state);
+            if (game_time != null)
+                state.SetGameTime(game_time);
 
-        private void TryConnect(LiveSplitState state)
-        {
-            _game = null;
-
-            var state_process = _states.Keys.Select(proccessName => new {
-                // default to the state with no version specified, if it exists
-                State = _states[proccessName].FirstOrDefault(s => s.GameVersion == "") ?? _states[proccessName].First(),
-                Process = Process.GetProcessesByName(proccessName).OrderByDescending(x => x.StartTime)
-                    .FirstOrDefault(x => !x.HasExited)
-            }).FirstOrDefault(x => x.Process != null);
-
-            if (state_process == null)
-                return;
-
-            _init_completed = false;
-            _game = state_process.Process;
-            State = state_process.State;
-
-            if (State.GameVersion == "")
+            if (RunMethod(_methods.reset, state) ?? false)
             {
-                Debug("Connected to game: {0} (using default state descriptor)", _game.ProcessName);
+                if (_settings.GetBasicSettingValue("reset"))
+                    _timer.Reset();
             }
-            else
+            else if (RunMethod(_methods.split, state) ?? false)
             {
-                Debug("Connected to game: {0} (state descriptor for version '{1}' chosen as default)",
-                    _game.ProcessName,
-                    State.GameVersion);
+                if (_settings.GetBasicSettingValue("split"))
+                    _timer.Split();
             }
-
-            DoInit(state);
         }
 
-        // This is executed each time after connecting to the game (usually just once,
-        // unless an error occurs before the method finishes).
-        private void DoInit(LiveSplitState state)
+        if (state.CurrentPhase == TimerPhase.NotRunning)
         {
-            Debug("Initializing");
-
-            State.RefreshValues(_game);
-            OldState = State;
-            GameVersion = string.Empty;
-
-            // Fetch version from init-method
-            var ver = string.Empty;
-            RunMethod(_methods.init, state, ref ver);
-
-            if (ver != GameVersion)
+            if (RunMethod(_methods.start, state) ?? false)
             {
-                GameVersion = ver;
-
-                var version_state = _states.Where(kv => kv.Key.ToLower() == _game.ProcessName.ToLower())
-                    .Select(kv => kv.Value)
-                    .First() // states
-                    .FirstOrDefault(s => s.GameVersion == ver);
-
-                if (version_state != null)
-                {
-                    // This state descriptor may already be selected
-                    if (version_state != State)
-                    {
-                        State = version_state;
-                        State.RefreshValues(_game);
-                        OldState = State;
-                        Debug($"Switched to state descriptor for version '{GameVersion}'");
-                    }
-                }
-                else
-                {
-                    Debug($"No state descriptor for version '{GameVersion}' (will keep using default one)");
-                }
-            }
-
-            _init_completed = true;
-            Debug("Init completed, running main methods");
-        }
-
-        private void DoExit(LiveSplitState state)
-        {
-            Debug("Running exit");
-            _game = null;
-            RunNoProcessMethod(_methods.exit, state);
-        }
-
-        // This is executed repeatedly as long as the game is connected and initialized.
-        private void DoUpdate(LiveSplitState state)
-        {
-            OldState = State.RefreshValues(_game);
-
-            if (!(RunMethod(_methods.update, state) ?? true))
-            {
-                // If Update explicitly returns false, don't run anything else
-                return;
-            }
-
-            if (state.CurrentPhase == TimerPhase.Running || state.CurrentPhase == TimerPhase.Paused)
-            {
-                if (_uses_game_time && !state.IsGameTimeInitialized)
-                    _timer.InitializeGameTime();
-
-                var is_paused = RunMethod(_methods.isLoading, state);
-                if (is_paused != null)
-                    state.IsGameTimePaused = is_paused;
-
-                var game_time = RunMethod(_methods.gameTime, state);
-                if (game_time != null)
-                    state.SetGameTime(game_time);
-
-                if (RunMethod(_methods.reset, state) ?? false)
-                {
-                    if (_settings.GetBasicSettingValue("reset"))
-                        _timer.Reset();
-                }
-                else if (RunMethod(_methods.split, state) ?? false)
-                {
-                    if (_settings.GetBasicSettingValue("split"))
-                        _timer.Split();
-                }
-            }
-
-            if (state.CurrentPhase == TimerPhase.NotRunning)
-            {
-                if (RunMethod(_methods.start, state) ?? false)
-                {
-                    if (_settings.GetBasicSettingValue("start"))
-                        _timer.Start();
-                }
+                if (_settings.GetBasicSettingValue("start"))
+                    _timer.Start();
             }
         }
+    }
 
-        private dynamic RunMethod(ASLMethod method, LiveSplitState state, ref string version)
-        {
-            var refresh_rate = RefreshRate;
-            var result = method.Call(state, Vars, ref version, ref refresh_rate, _settings.Reader,
-                OldState?.Data, State?.Data, _game);
-            RefreshRate = refresh_rate;
-            return result;
-        }
+    private dynamic RunMethod(ASLMethod method, LiveSplitState state, ref string version)
+    {
+        var refresh_rate = RefreshRate;
+        var result = method.Call(state, Vars, ref version, ref refresh_rate, _settings.Reader,
+            OldState?.Data, State?.Data, _game);
+        RefreshRate = refresh_rate;
+        return result;
+    }
 
-        private dynamic RunMethod(ASLMethod method, LiveSplitState state)
-        {
-            var version = GameVersion;
-            return RunMethod(method, state, ref version);
-        }
+    private dynamic RunMethod(ASLMethod method, LiveSplitState state)
+    {
+        var version = GameVersion;
+        return RunMethod(method, state, ref version);
+    }
 
-        // Run method without counting on being connected to the game (startup/shutdown).
-        private void RunNoProcessMethod(ASLMethod method, LiveSplitState state, bool is_startup = false)
-        {
-            var refresh_rate = RefreshRate;
-            var version = GameVersion;
-            method.Call(state, Vars, ref version, ref refresh_rate,
-                is_startup ? _settings.Builder : (object)_settings.Reader);
-            RefreshRate = refresh_rate;
-        }
+    // Run method without counting on being connected to the game (startup/shutdown).
+    private void RunNoProcessMethod(ASLMethod method, LiveSplitState state, bool is_startup = false)
+    {
+        var refresh_rate = RefreshRate;
+        var version = GameVersion;
+        method.Call(state, Vars, ref version, ref refresh_rate,
+            is_startup ? _settings.Builder : (object)_settings.Reader);
+        RefreshRate = refresh_rate;
+    }
 
-        private void Debug(string output, params object[] args)
-        {
-            Log.Info(String.Format("[ASL/{1}] {0}",
-                String.Format(output, args),
-                this.GetHashCode()));
-        }
+    private void Debug(string output, params object[] args)
+    {
+        Log.Info(String.Format("[ASL/{1}] {0}",
+            String.Format(output, args),
+            this.GetHashCode()));
     }
 }

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLScript.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLScript.cs
@@ -142,10 +142,7 @@ public class ASLScript
     {
         if (_game == null)
         {
-            if (_timer == null)
-            {
-                _timer = new TimerModel() { CurrentState = state };
-            }
+            _timer ??= new TimerModel() { CurrentState = state };
 
             TryConnect(state);
         }

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLSettings.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLSettings.cs
@@ -1,180 +1,180 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using LiveSplit.Options;
 
-namespace LiveSplit.ASL
+namespace LiveSplit.ASL;
+
+// Created from the ASL script and shared with the GUI to synchronize setting state.
+public class ASLSetting
 {
-    // Created from the ASL script and shared with the GUI to synchronize setting state.
-    public class ASLSetting
+    public string Id { get; }
+    public string Label { get; }
+    public bool Value { get; set; }
+    public bool DefaultValue { get; }
+    public string Parent { get; }
+    public string ToolTip { get; set; }
+
+    public ASLSetting(string id, bool default_value, string label, string parent)
     {
-        public string Id { get; }
-        public string Label { get; }
-        public bool Value { get; set; }
-        public bool DefaultValue { get; }
-        public string Parent { get; }
-        public string ToolTip { get; set; }
-
-        public ASLSetting(string id, bool default_value, string label, string parent)
-        {
-            Id = id;
-            Value = default_value;
-            DefaultValue = default_value;
-            Label = label;
-            Parent = parent;
-        }
-
-        public override string ToString()
-        {
-            return Label;
-        }
+        Id = id;
+        Value = default_value;
+        DefaultValue = default_value;
+        Label = label;
+        Parent = parent;
     }
 
-    public class ASLSettings
+    public override string ToString()
     {
-        // Dict for easy access per key
-        public Dictionary<string, ASLSetting> Settings { get; set; }
-        // List for preserved insertion order (Dict provides that as well, but not guaranteed)
-        public List<ASLSetting> OrderedSettings { get; }
-
-        public Dictionary<string, ASLSetting> BasicSettings { get; }
-
-        public ASLSettingsBuilder Builder;
-        public ASLSettingsReader Reader;
-        
-        public ASLSettings()
-        {
-            Settings = new Dictionary<string, ASLSetting>();
-            OrderedSettings = new List<ASLSetting>();
-            BasicSettings = new Dictionary<string, ASLSetting>();
-            Builder = new ASLSettingsBuilder(this);
-            Reader = new ASLSettingsReader(this);
-        }
-
-        public void AddSetting(string name, bool default_value, string description, string parent)
-        {
-            if (description == null)
-                description = name;
-            if (parent != null && !Settings.ContainsKey(parent))
-                throw new ArgumentException($"Parent for setting '{name}' is not a setting: {parent}");
-            if (Settings.ContainsKey(name))
-                throw new ArgumentException($"Setting '{name}' was already added");
-
-            var setting = new ASLSetting(name, default_value, description, parent);
-            Settings.Add(name, setting);
-            OrderedSettings.Add(setting);
-        }
-
-        public bool GetSettingValue(string name)
-        {
-            // Don't cause error if setting doesn't exist, but still inform script
-            // author since that usually shouldn't happen.
-            if (Settings.ContainsKey(name))
-                return GetSettingValueRecursive(Settings[name]);
-
-            Log.Info("[ASL] Custom Setting Key doesn't exist: " + name);
-
-            return false;
-        }
-
-        public void AddBasicSetting(string name)
-        {
-            BasicSettings.Add(name, new ASLSetting(name, true, "", null));
-        }
-
-        public bool GetBasicSettingValue(string name)
-        {
-            if (BasicSettings.ContainsKey(name))
-                return BasicSettings[name].Value;
-
-            return false;
-        }
-
-        public bool IsBasicSettingPresent(string name)
-        {
-            return BasicSettings.ContainsKey(name);
-        }
-
-
-        /// <summary>
-        /// Returns true only if this setting and all it's parent settings are true.
-        /// </summary>
-        private bool GetSettingValueRecursive(ASLSetting setting)
-        {
-            if (!setting.Value)
-                return false;
-
-            if (setting.Parent == null)
-                return setting.Value;
-
-            return GetSettingValueRecursive(Settings[setting.Parent]);
-        }
+        return Label;
     }
+}
+
+public class ASLSettings
+{
+    // Dict for easy access per key
+    public Dictionary<string, ASLSetting> Settings { get; set; }
+    // List for preserved insertion order (Dict provides that as well, but not guaranteed)
+    public List<ASLSetting> OrderedSettings { get; }
+
+    public Dictionary<string, ASLSetting> BasicSettings { get; }
+
+    public ASLSettingsBuilder Builder;
+    public ASLSettingsReader Reader;
+
+    public ASLSettings()
+    {
+        Settings = new Dictionary<string, ASLSetting>();
+        OrderedSettings = new List<ASLSetting>();
+        BasicSettings = new Dictionary<string, ASLSetting>();
+        Builder = new ASLSettingsBuilder(this);
+        Reader = new ASLSettingsReader(this);
+    }
+
+    public void AddSetting(string name, bool default_value, string description, string parent)
+    {
+        if (description == null)
+            description = name;
+        if (parent != null && !Settings.ContainsKey(parent))
+            throw new ArgumentException($"Parent for setting '{name}' is not a setting: {parent}");
+        if (Settings.ContainsKey(name))
+            throw new ArgumentException($"Setting '{name}' was already added");
+
+        var setting = new ASLSetting(name, default_value, description, parent);
+        Settings.Add(name, setting);
+        OrderedSettings.Add(setting);
+    }
+
+    public bool GetSettingValue(string name)
+    {
+        // Don't cause error if setting doesn't exist, but still inform script
+        // author since that usually shouldn't happen.
+        if (Settings.ContainsKey(name))
+            return GetSettingValueRecursive(Settings[name]);
+
+        Log.Info("[ASL] Custom Setting Key doesn't exist: " + name);
+
+        return false;
+    }
+
+    public void AddBasicSetting(string name)
+    {
+        BasicSettings.Add(name, new ASLSetting(name, true, "", null));
+    }
+
+    public bool GetBasicSettingValue(string name)
+    {
+        if (BasicSettings.ContainsKey(name))
+            return BasicSettings[name].Value;
+
+        return false;
+    }
+
+    public bool IsBasicSettingPresent(string name)
+    {
+        return BasicSettings.ContainsKey(name);
+    }
+
 
     /// <summary>
-    /// Interface for adding settings via the ASL Script.
+    /// Returns true only if this setting and all it's parent settings are true.
     /// </summary>
-    public class ASLSettingsBuilder
+    private bool GetSettingValueRecursive(ASLSetting setting)
     {
-        public string CurrentDefaultParent { get; set; }
-        private ASLSettings _s;
+        if (!setting.Value)
+            return false;
 
-        public ASLSettingsBuilder(ASLSettings s)
-        {
-            _s = s;
-        }
+        if (setting.Parent == null)
+            return setting.Value;
 
-        public void Add(string id, bool default_value = true, string description = null, string parent = null)
-        {
-            if (parent == null)
-                parent = CurrentDefaultParent;
+        return GetSettingValueRecursive(Settings[setting.Parent]);
+    }
+}
 
-            _s.AddSetting(id, default_value, description, parent);
-        }
+/// <summary>
+/// Interface for adding settings via the ASL Script.
+/// </summary>
+public class ASLSettingsBuilder
+{
+    public string CurrentDefaultParent { get; set; }
+    private ASLSettings _s;
 
-        public void SetToolTip(string id, string text)
-        {
-            if (!_s.Settings.ContainsKey(id))
-                throw new ArgumentException($"Can't set tooltip, '{id}' is not a setting");
-
-            _s.Settings[id].ToolTip = text;
-        }
+    public ASLSettingsBuilder(ASLSettings s)
+    {
+        _s = s;
     }
 
-    /// <summary>
-    /// Interface for reading settings via the ASL Script.
-    /// </summary>
-    public class ASLSettingsReader
+    public void Add(string id, bool default_value = true, string description = null, string parent = null)
     {
-        private ASLSettings _s;
+        if (parent == null)
+            parent = CurrentDefaultParent;
 
-        public ASLSettingsReader(ASLSettings s)
-        {
-            _s = s;
-        }
+        _s.AddSetting(id, default_value, description, parent);
+    }
 
-        public dynamic this[string id]
-        {
-            get { return _s.GetSettingValue(id); }
-        }
-        
-        public bool ContainsKey(string key)
-        {
-            return _s.Settings.ContainsKey(key);   
-        }
+    public void SetToolTip(string id, string text)
+    {
+        if (!_s.Settings.ContainsKey(id))
+            throw new ArgumentException($"Can't set tooltip, '{id}' is not a setting");
 
-        public bool StartEnabled
-        {
-            get { return _s.GetBasicSettingValue("start"); }
-        }
+        _s.Settings[id].ToolTip = text;
+    }
+}
 
-        public bool ResetEnabled
-        {
-            get { return _s.GetBasicSettingValue("reset"); }
-        }
+/// <summary>
+/// Interface for reading settings via the ASL Script.
+/// </summary>
+public class ASLSettingsReader
+{
+    private ASLSettings _s;
 
-        public bool SplitEnabled
-        {
-            get { return _s.GetBasicSettingValue("split"); }
-        }
+    public ASLSettingsReader(ASLSettings s)
+    {
+        _s = s;
+    }
+
+    public dynamic this[string id]
+    {
+        get { return _s.GetSettingValue(id); }
+    }
+
+    public bool ContainsKey(string key)
+    {
+        return _s.Settings.ContainsKey(key);
+    }
+
+    public bool StartEnabled
+    {
+        get { return _s.GetBasicSettingValue("start"); }
+    }
+
+    public bool ResetEnabled
+    {
+        get { return _s.GetBasicSettingValue("reset"); }
+    }
+
+    public bool SplitEnabled
+    {
+        get { return _s.GetBasicSettingValue("split"); }
     }
 }

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLSettings.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLSettings.cs
@@ -153,28 +153,16 @@ public class ASLSettingsReader
         _s = s;
     }
 
-    public dynamic this[string id]
-    {
-        get { return _s.GetSettingValue(id); }
-    }
+    public dynamic this[string id] => _s.GetSettingValue(id);
 
     public bool ContainsKey(string key)
     {
         return _s.Settings.ContainsKey(key);
     }
 
-    public bool StartEnabled
-    {
-        get { return _s.GetBasicSettingValue("start"); }
-    }
+    public bool StartEnabled => _s.GetBasicSettingValue("start");
 
-    public bool ResetEnabled
-    {
-        get { return _s.GetBasicSettingValue("reset"); }
-    }
+    public bool ResetEnabled => _s.GetBasicSettingValue("reset");
 
-    public bool SplitEnabled
-    {
-        get { return _s.GetBasicSettingValue("split"); }
-    }
+    public bool SplitEnabled => _s.GetBasicSettingValue("split");
 }

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLSettings.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLSettings.cs
@@ -53,10 +53,7 @@ public class ASLSettings
 
     public void AddSetting(string name, bool default_value, string description, string parent)
     {
-        if (description == null)
-        {
-            description = name;
-        }
+        description ??= name;
 
         if (parent != null && !Settings.ContainsKey(parent))
         {
@@ -141,10 +138,7 @@ public class ASLSettingsBuilder
 
     public void Add(string id, bool default_value = true, string description = null, string parent = null)
     {
-        if (parent == null)
-        {
-            parent = CurrentDefaultParent;
-        }
+        parent ??= CurrentDefaultParent;
 
         _s.AddSetting(id, default_value, description, parent);
     }

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLSettings.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLSettings.cs
@@ -117,7 +117,7 @@ public class ASLSettings
 public class ASLSettingsBuilder
 {
     public string CurrentDefaultParent { get; set; }
-    private ASLSettings _s;
+    private readonly ASLSettings _s;
 
     public ASLSettingsBuilder(ASLSettings s)
     {
@@ -146,7 +146,7 @@ public class ASLSettingsBuilder
 /// </summary>
 public class ASLSettingsReader
 {
-    private ASLSettings _s;
+    private readonly ASLSettings _s;
 
     public ASLSettingsReader(ASLSettings s)
     {

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLSettings.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLSettings.cs
@@ -54,11 +54,19 @@ public class ASLSettings
     public void AddSetting(string name, bool default_value, string description, string parent)
     {
         if (description == null)
+        {
             description = name;
+        }
+
         if (parent != null && !Settings.ContainsKey(parent))
+        {
             throw new ArgumentException($"Parent for setting '{name}' is not a setting: {parent}");
+        }
+
         if (Settings.ContainsKey(name))
+        {
             throw new ArgumentException($"Setting '{name}' was already added");
+        }
 
         var setting = new ASLSetting(name, default_value, description, parent);
         Settings.Add(name, setting);
@@ -70,7 +78,9 @@ public class ASLSettings
         // Don't cause error if setting doesn't exist, but still inform script
         // author since that usually shouldn't happen.
         if (Settings.ContainsKey(name))
+        {
             return GetSettingValueRecursive(Settings[name]);
+        }
 
         Log.Info("[ASL] Custom Setting Key doesn't exist: " + name);
 
@@ -85,7 +95,9 @@ public class ASLSettings
     public bool GetBasicSettingValue(string name)
     {
         if (BasicSettings.ContainsKey(name))
+        {
             return BasicSettings[name].Value;
+        }
 
         return false;
     }
@@ -95,17 +107,20 @@ public class ASLSettings
         return BasicSettings.ContainsKey(name);
     }
 
-
     /// <summary>
     /// Returns true only if this setting and all it's parent settings are true.
     /// </summary>
     private bool GetSettingValueRecursive(ASLSetting setting)
     {
         if (!setting.Value)
+        {
             return false;
+        }
 
         if (setting.Parent == null)
+        {
             return setting.Value;
+        }
 
         return GetSettingValueRecursive(Settings[setting.Parent]);
     }
@@ -127,7 +142,9 @@ public class ASLSettingsBuilder
     public void Add(string id, bool default_value = true, string description = null, string parent = null)
     {
         if (parent == null)
+        {
             parent = CurrentDefaultParent;
+        }
 
         _s.AddSetting(id, default_value, description, parent);
     }
@@ -135,7 +152,9 @@ public class ASLSettingsBuilder
     public void SetToolTip(string id, string text)
     {
         if (!_s.Settings.ContainsKey(id))
+        {
             throw new ArgumentException($"Can't set tooltip, '{id}' is not a setting");
+        }
 
         _s.Settings[id].ToolTip = text;
     }

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLSettings.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLSettings.cs
@@ -44,9 +44,9 @@ public class ASLSettings
 
     public ASLSettings()
     {
-        Settings = new Dictionary<string, ASLSetting>();
-        OrderedSettings = new List<ASLSetting>();
-        BasicSettings = new Dictionary<string, ASLSetting>();
+        Settings = [];
+        OrderedSettings = [];
+        BasicSettings = [];
         Builder = new ASLSettingsBuilder(this);
         Reader = new ASLSettingsReader(this);
     }

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLState.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLState.cs
@@ -2,99 +2,99 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Dynamic;
+
 using LiveSplit.ComponentUtil;
 
-namespace LiveSplit.ASL
+namespace LiveSplit.ASL;
+
+public class ASLValueDefinition
 {
-    public class ASLValueDefinition
+    public string Type { get; set; }
+    public string Identifier { get; set; }
+    public DeepPointer Pointer { get; set; }
+}
+
+public class ASLState : ICloneable
+{
+    public ExpandoObject Data { get; set; }
+    public List<ASLValueDefinition> ValueDefinitions { get; set; }
+    public string GameVersion { get; set; }
+
+    public ASLState()
     {
-        public string Type { get; set; }
-        public string Identifier { get; set; }
-        public DeepPointer Pointer { get; set; }
+        Data = new ExpandoObject();
+        ValueDefinitions = new List<ASLValueDefinition>();
+        GameVersion = string.Empty;
     }
 
-    public class ASLState : ICloneable
+    public ASLState RefreshValues(Process p)
     {
-        public ExpandoObject Data { get; set; }
-        public List<ASLValueDefinition> ValueDefinitions { get; set; }
-        public string GameVersion { get; set; }
+        var clone = (ASLState)Clone();
+        var dict = ((IDictionary<string, object>)Data);
 
-        public ASLState()
+        foreach (var value_definition in ValueDefinitions)
         {
-            Data = new ExpandoObject();
-            ValueDefinitions = new List<ASLValueDefinition>();
-            GameVersion = string.Empty;
+            var value = GetValue(p, value_definition.Type, value_definition.Pointer);
+
+            if (dict.ContainsKey(value_definition.Identifier))
+                dict[value_definition.Identifier] = value;
+            else
+                dict.Add(value_definition.Identifier, value);
         }
 
-        public ASLState RefreshValues(Process p)
+        return clone;
+    }
+
+    private static dynamic GetValue(Process p, string type, DeepPointer pointer)
+    {
+        switch (type)
         {
-            var clone = (ASLState)Clone();
-            var dict = ((IDictionary<string, object>)Data);
-
-            foreach (var value_definition in ValueDefinitions)
-            {
-                var value = GetValue(p, value_definition.Type, value_definition.Pointer);
-
-                if (dict.ContainsKey(value_definition.Identifier))
-                    dict[value_definition.Identifier] = value;
-                else
-                    dict.Add(value_definition.Identifier, value);
-            }
-
-            return clone;
+            case "int":
+                return pointer.Deref<int>(p);
+            case "uint":
+                return pointer.Deref<uint>(p);
+            case "long":
+                return pointer.Deref<long>(p);
+            case "ulong":
+                return pointer.Deref<ulong>(p);
+            case "float":
+                return pointer.Deref<float>(p);
+            case "double":
+                return pointer.Deref<double>(p);
+            case "byte":
+                return pointer.Deref<byte>(p);
+            case "sbyte":
+                return pointer.Deref<sbyte>(p);
+            case "short":
+                return pointer.Deref<short>(p);
+            case "ushort":
+                return pointer.Deref<ushort>(p);
+            case "bool":
+                return pointer.Deref<bool>(p);
+            default:
+                if (type.StartsWith("string"))
+                {
+                    var length = int.Parse(type.Substring("string".Length));
+                    return pointer.DerefString(p, length);
+                }
+                else if (type.StartsWith("byte"))
+                {
+                    var length = int.Parse(type.Substring("byte".Length));
+                    return pointer.DerefBytes(p, length);
+                }
+                break;
         }
 
-        private static dynamic GetValue(Process p, string type, DeepPointer pointer)
-        {
-            switch (type)
-            {
-                case "int":
-                    return pointer.Deref<int>(p);
-                case "uint":
-                    return pointer.Deref<uint>(p);
-                case "long":
-                    return pointer.Deref<long>(p);
-                case "ulong":
-                    return pointer.Deref<ulong>(p);
-                case "float":
-                    return pointer.Deref<float>(p);
-                case "double":
-                    return pointer.Deref<double>(p);
-                case "byte":
-                    return pointer.Deref<byte>(p);
-                case "sbyte":
-                    return pointer.Deref<sbyte>(p);
-                case "short":
-                    return pointer.Deref<short>(p);
-                case "ushort":
-                    return pointer.Deref<ushort>(p);
-                case "bool":
-                    return pointer.Deref<bool>(p);
-                default:
-                    if (type.StartsWith("string"))
-                    {
-                        var length = int.Parse(type.Substring("string".Length));
-                        return pointer.DerefString(p, length);
-                    }
-                    else if (type.StartsWith("byte"))
-                    {
-                        var length = int.Parse(type.Substring("byte".Length));
-                        return pointer.DerefBytes(p, length);
-                    }
-                    break;
-            }
+        throw new ArgumentException($"The provided type, '{type}', is not supported");
+    }
 
-            throw new ArgumentException($"The provided type, '{type}', is not supported");
-        }
-
-        public object Clone()
+    public object Clone()
+    {
+        var clone = new ExpandoObject();
+        foreach (var pair in Data)
         {
-            var clone = new ExpandoObject();
-            foreach (var pair in Data)
-            {
-                ((IDictionary<string, object>)clone).Add(pair);
-            }
-            return new ASLState() { Data = clone, ValueDefinitions = new List<ASLValueDefinition>(ValueDefinitions) };
+            ((IDictionary<string, object>)clone).Add(pair);
         }
+        return new ASLState() { Data = clone, ValueDefinitions = new List<ASLValueDefinition>(ValueDefinitions) };
     }
 }

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLState.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLState.cs
@@ -30,16 +30,20 @@ public class ASLState : ICloneable
     public ASLState RefreshValues(Process p)
     {
         var clone = (ASLState)Clone();
-        var dict = ((IDictionary<string, object>)Data);
+        var dict = (IDictionary<string, object>)Data;
 
         foreach (var value_definition in ValueDefinitions)
         {
             var value = GetValue(p, value_definition.Type, value_definition.Pointer);
 
             if (dict.ContainsKey(value_definition.Identifier))
+            {
                 dict[value_definition.Identifier] = value;
+            }
             else
+            {
                 dict.Add(value_definition.Identifier, value);
+            }
         }
 
         return clone;
@@ -82,6 +86,7 @@ public class ASLState : ICloneable
                     var length = int.Parse(type.Substring("byte".Length));
                     return pointer.DerefBytes(p, length);
                 }
+
                 break;
         }
 
@@ -95,6 +100,7 @@ public class ASLState : ICloneable
         {
             ((IDictionary<string, object>)clone).Add(pair);
         }
+
         return new ASLState() { Data = clone, ValueDefinitions = new List<ASLValueDefinition>(ValueDefinitions) };
     }
 }

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLState.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLState.cs
@@ -32,9 +32,9 @@ public class ASLState : ICloneable
         var clone = (ASLState)Clone();
         var dict = (IDictionary<string, object>)Data;
 
-        foreach (var value_definition in ValueDefinitions)
+        foreach (ASLValueDefinition value_definition in ValueDefinitions)
         {
-            var value = GetValue(p, value_definition.Type, value_definition.Pointer);
+            dynamic value = GetValue(p, value_definition.Type, value_definition.Pointer);
 
             if (dict.ContainsKey(value_definition.Identifier))
             {
@@ -78,12 +78,12 @@ public class ASLState : ICloneable
             default:
                 if (type.StartsWith("string"))
                 {
-                    var length = int.Parse(type.Substring("string".Length));
+                    int length = int.Parse(type.Substring("string".Length));
                     return pointer.DerefString(p, length);
                 }
                 else if (type.StartsWith("byte"))
                 {
-                    var length = int.Parse(type.Substring("byte".Length));
+                    int length = int.Parse(type.Substring("byte".Length));
                     return pointer.DerefBytes(p, length);
                 }
 
@@ -96,7 +96,7 @@ public class ASLState : ICloneable
     public object Clone()
     {
         var clone = new ExpandoObject();
-        foreach (var pair in Data)
+        foreach (KeyValuePair<string, object> pair in Data)
         {
             ((IDictionary<string, object>)clone).Add(pair);
         }

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLState.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLState.cs
@@ -78,12 +78,12 @@ public class ASLState : ICloneable
             default:
                 if (type.StartsWith("string"))
                 {
-                    int length = int.Parse(type.Substring("string".Length));
+                    int length = int.Parse(type["string".Length..]);
                     return pointer.DerefString(p, length);
                 }
                 else if (type.StartsWith("byte"))
                 {
-                    int length = int.Parse(type.Substring("byte".Length));
+                    int length = int.Parse(type["byte".Length..]);
                     return pointer.DerefBytes(p, length);
                 }
 

--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLState.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLState.cs
@@ -23,7 +23,7 @@ public class ASLState : ICloneable
     public ASLState()
     {
         Data = new ExpandoObject();
-        ValueDefinitions = new List<ASLValueDefinition>();
+        ValueDefinitions = [];
         GameVersion = string.Empty;
     }
 

--- a/src/LiveSplit.ScriptableAutoSplit/Component.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/Component.cs
@@ -22,12 +22,12 @@ public class ASLComponent : LogicComponent
     private bool _do_reload;
     private string _old_script_path;
 
-    private Timer _update_timer;
-    private FileSystemWatcher _fs_watcher;
+    private readonly Timer _update_timer;
+    private readonly FileSystemWatcher _fs_watcher;
 
-    private ComponentSettings _settings;
+    private readonly ComponentSettings _settings;
 
-    private LiveSplitState _state;
+    private readonly LiveSplitState _state;
 
     public ASLComponent(LiveSplitState state)
     {

--- a/src/LiveSplit.ScriptableAutoSplit/Component.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/Component.cs
@@ -41,7 +41,7 @@ public class ASLComponent : LogicComponent
         {
             await Task.Delay(200);
             _do_reload = true;
-        };
+        }
 
         _fs_watcher.Changed += handler;
         _fs_watcher.Renamed += handler;
@@ -95,7 +95,6 @@ public class ASLComponent : LogicComponent
     public override void Update(IInvalidator invalidator, LiveSplitState state, float width, float height,
         LayoutMode mode)
     { }
-
 
     private void UpdateScript()
     {
@@ -184,7 +183,9 @@ public class ASLComponent : LogicComponent
     private void ScriptCleanup()
     {
         if (Script == null)
+        {
             return;
+        }
 
         try
         {

--- a/src/LiveSplit.ScriptableAutoSplit/Component.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/Component.cs
@@ -1,207 +1,207 @@
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Xml;
+
 using LiveSplit.ASL;
 using LiveSplit.Model;
 using LiveSplit.Options;
 
-namespace LiveSplit.UI.Components
+namespace LiveSplit.UI.Components;
+
+public class ASLComponent : LogicComponent
 {
-    public class ASLComponent : LogicComponent
+    public override string ComponentName => "Scriptable Auto Splitter";
+
+    // public so other components (ASLVarViewer) can access
+    public ASLScript Script { get; private set; }
+
+    public event EventHandler ScriptChanged;
+
+    private bool _do_reload;
+    private string _old_script_path;
+
+    private Timer _update_timer;
+    private FileSystemWatcher _fs_watcher;
+
+    private ComponentSettings _settings;
+
+    private LiveSplitState _state;
+
+    public ASLComponent(LiveSplitState state)
     {
-        public override string ComponentName => "Scriptable Auto Splitter";
+        _state = state;
 
-        // public so other components (ASLVarViewer) can access
-        public ASLScript Script { get; private set; }
+        _settings = new ComponentSettings();
 
-        public event EventHandler ScriptChanged;
+        _fs_watcher = new FileSystemWatcher();
 
-        private bool _do_reload;
-        private string _old_script_path;
-
-        private Timer _update_timer;
-        private FileSystemWatcher _fs_watcher;
-
-        private ComponentSettings _settings;
-
-        private LiveSplitState _state;
-
-        public ASLComponent(LiveSplitState state)
+        async void handler<T>(object sender, T args)
         {
-            _state = state;
+            await Task.Delay(200);
+            _do_reload = true;
+        };
 
-            _settings = new ComponentSettings();
+        _fs_watcher.Changed += handler;
+        _fs_watcher.Renamed += handler;
 
-            _fs_watcher = new FileSystemWatcher();
+        // -try- to run a little faster than 60hz
+        // note: Timer isn't very reliable and quite often takes ~30ms
+        // we need to switch to threading
+        _update_timer = new Timer() { Interval = 15 };
+        _update_timer.Tick += (sender, args) => UpdateScript();
+        _update_timer.Enabled = true;
+    }
 
-            async void handler<T>(object sender, T args)
-            {
-              await Task.Delay(200);
-              _do_reload = true;
-            };
+    public ASLComponent(LiveSplitState state, string script_path)
+        : this(state)
+    {
+        _settings = new ComponentSettings(script_path);
+    }
 
-            _fs_watcher.Changed += handler;
-            _fs_watcher.Renamed += handler;
+    public override void Dispose()
+    {
+        ScriptCleanup();
 
-            // -try- to run a little faster than 60hz
-            // note: Timer isn't very reliable and quite often takes ~30ms
-            // we need to switch to threading
-            _update_timer = new Timer() { Interval = 15 };
-            _update_timer.Tick += (sender, args) => UpdateScript();
-            _update_timer.Enabled = true;
+        try
+        {
+            ScriptChanged?.Invoke(this, EventArgs.Empty);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
         }
 
-        public ASLComponent(LiveSplitState state, string script_path)
-            : this(state)
-        {
-            _settings = new ComponentSettings(script_path);
-        }
+        _fs_watcher?.Dispose();
+        _update_timer?.Dispose();
+    }
 
-        public override void Dispose()
-        {
-            ScriptCleanup();
+    public override Control GetSettingsControl(LayoutMode mode)
+    {
+        return _settings;
+    }
 
+    public override XmlNode GetSettings(XmlDocument document)
+    {
+        return _settings.GetSettings(document);
+    }
+
+    public override void SetSettings(XmlNode settings)
+    {
+        _settings.SetSettings(settings);
+    }
+
+    public override void Update(IInvalidator invalidator, LiveSplitState state, float width, float height,
+        LayoutMode mode)
+    { }
+
+
+    private void UpdateScript()
+    {
+        // Disable timer, to wait for execution of this iteration to
+        // finish. This can be useful if blocking operations like
+        // showing a message window are used.
+        _update_timer.Enabled = false;
+
+        // this is ugly, fix eventually!
+        if (_settings.ScriptPath != _old_script_path || _do_reload)
+        {
             try
             {
+                _do_reload = false;
+                _old_script_path = _settings.ScriptPath;
+
+                ScriptCleanup();
+
+                if (string.IsNullOrEmpty(_settings.ScriptPath))
+                {
+                    // Only disable file watcher if script path changed to empty
+                    // (otherwise detecting file changes may still be wanted)
+                    _fs_watcher.EnableRaisingEvents = false;
+                }
+                else
+                {
+                    LoadScript();
+                }
+
                 ScriptChanged?.Invoke(this, EventArgs.Empty);
             }
             catch (Exception ex)
             {
                 Log.Error(ex);
             }
-
-            _fs_watcher?.Dispose();
-            _update_timer?.Dispose();
         }
 
-        public override Control GetSettingsControl(LayoutMode mode)
+        if (Script != null)
         {
-            return _settings;
-        }
-
-        public override XmlNode GetSettings(XmlDocument document)
-        {
-            return _settings.GetSettings(document);
-        }
-
-        public override void SetSettings(XmlNode settings)
-        {
-            _settings.SetSettings(settings);
-        }
-
-        public override void Update(IInvalidator invalidator, LiveSplitState state, float width, float height,
-            LayoutMode mode) { }
-
-
-        private void UpdateScript()
-        {
-            // Disable timer, to wait for execution of this iteration to
-            // finish. This can be useful if blocking operations like
-            // showing a message window are used.
-            _update_timer.Enabled = false;
-
-            // this is ugly, fix eventually!
-            if (_settings.ScriptPath != _old_script_path || _do_reload)
+            try
             {
-                try
-                {
-                    _do_reload = false;
-                    _old_script_path = _settings.ScriptPath;
-
-                    ScriptCleanup();
-
-                    if (string.IsNullOrEmpty(_settings.ScriptPath))
-                    {
-                        // Only disable file watcher if script path changed to empty
-                        // (otherwise detecting file changes may still be wanted)
-                        _fs_watcher.EnableRaisingEvents = false;
-                    }
-                    else
-                    {
-                        LoadScript();
-                    }
-
-                    ScriptChanged?.Invoke(this, EventArgs.Empty);
-                }
-                catch (Exception ex)
-                {
-                    Log.Error(ex);
-                }
+                Script.Update(_state);
             }
-
-            if (Script != null)
+            catch (Exception ex)
             {
-                try
-                {
-                    Script.Update(_state);
-                }
-                catch (Exception ex)
-                {
-                    Log.Error(ex);
-                }
+                Log.Error(ex);
             }
-
-            _update_timer.Enabled = true;
         }
 
-        private void LoadScript()
+        _update_timer.Enabled = true;
+    }
+
+    private void LoadScript()
+    {
+        Log.Info("[ASL] Loading new script: " + _settings.ScriptPath);
+
+        _fs_watcher.Path = Path.GetDirectoryName(_settings.ScriptPath);
+        _fs_watcher.Filter = Path.GetFileName(_settings.ScriptPath);
+        _fs_watcher.EnableRaisingEvents = true;
+
+        // New script
+        Script = ASLParser.Parse(File.ReadAllText(_settings.ScriptPath));
+
+        Script.RefreshRateChanged += (sender, rate) => _update_timer.Interval = (int)Math.Round(1000 / rate);
+        _update_timer.Interval = (int)Math.Round(1000 / Script.RefreshRate);
+
+        Script.GameVersionChanged += (sender, version) => _settings.SetGameVersion(version);
+        _settings.SetGameVersion(null);
+
+        // Give custom ASL settings to GUI, which populates the list and
+        // stores the ASLSetting objects which are shared between the GUI
+        // and ASLScript
+        try
         {
-            Log.Info("[ASL] Loading new script: " + _settings.ScriptPath);
+            ASLSettings settings = Script.RunStartup(_state);
+            _settings.SetASLSettings(settings);
+        }
+        catch (Exception ex)
+        {
+            // Script already created, but startup failed, so clean up again
+            Log.Error(ex);
+            ScriptCleanup();
+        }
+    }
 
-            _fs_watcher.Path = Path.GetDirectoryName(_settings.ScriptPath);
-            _fs_watcher.Filter = Path.GetFileName(_settings.ScriptPath);
-            _fs_watcher.EnableRaisingEvents = true;
+    private void ScriptCleanup()
+    {
+        if (Script == null)
+            return;
 
-            // New script
-            Script = ASLParser.Parse(File.ReadAllText(_settings.ScriptPath));
-
-            Script.RefreshRateChanged += (sender, rate) => _update_timer.Interval = (int)Math.Round(1000 / rate);
-            _update_timer.Interval = (int)Math.Round(1000 / Script.RefreshRate);
-
-            Script.GameVersionChanged += (sender, version) => _settings.SetGameVersion(version);
+        try
+        {
+            Script.RunShutdown(_state);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex);
+        }
+        finally
+        {
             _settings.SetGameVersion(null);
+            _settings.ResetASLSettings();
 
-            // Give custom ASL settings to GUI, which populates the list and
-            // stores the ASLSetting objects which are shared between the GUI
-            // and ASLScript
-            try
-            {
-                ASLSettings settings = Script.RunStartup(_state);
-                _settings.SetASLSettings(settings);
-            }
-            catch (Exception ex)
-            {
-                // Script already created, but startup failed, so clean up again
-                Log.Error(ex);
-                ScriptCleanup();
-            }
-        }
-
-        private void ScriptCleanup()
-        {
-            if (Script == null)
-                return;
-
-            try
-            {
-                Script.RunShutdown(_state);
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-            }
-            finally
-            {
-                _settings.SetGameVersion(null);
-                _settings.ResetASLSettings();
-
-                // Script should no longer be used, even in case of error
-                // (which the ASL shutdown method may contain)
-                Script = null;
-            }
+            // Script should no longer be used, even in case of error
+            // (which the ASL shutdown method may contain)
+            Script = null;
         }
     }
 }

--- a/src/LiveSplit.ScriptableAutoSplit/ComponentSettings.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ComponentSettings.cs
@@ -16,7 +16,7 @@ public partial class ComponentSettings : UserControl
     // if true, next path loaded from settings will be ignored
     private bool _ignore_next_path_setting;
 
-    private Dictionary<string, CheckBox> _basic_settings;
+    private readonly Dictionary<string, CheckBox> _basic_settings;
 
     // Save the state of settings independant of actual ASLSetting objects
     // or the actual GUI components (checkboxes). This is used to restore
@@ -32,7 +32,7 @@ public partial class ComponentSettings : UserControl
     // if no script is currently loaded.
 
     // Start/Reset/Split checkboxes
-    private Dictionary<string, bool> _basic_settings_state;
+    private readonly Dictionary<string, bool> _basic_settings_state;
 
     // Custom settings
     private Dictionary<string, bool> _custom_settings_state;
@@ -535,7 +535,7 @@ public partial class ComponentSettings : UserControl
 /// See also:
 /// http://stackoverflow.com/questions/17356976/treeview-with-checkboxes-not-processing-clicks-correctly
 /// http://stackoverflow.com/questions/14647216/c-sharp-treeview-ignore-double-click-only-at-checkbox
-class NewTreeView : TreeView
+internal class NewTreeView : TreeView
 {
     protected override void WndProc(ref Message m)
     {

--- a/src/LiveSplit.ScriptableAutoSplit/ComponentSettings.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ComponentSettings.cs
@@ -57,8 +57,8 @@ public partial class ComponentSettings : UserControl
             ["Split"] = checkboxSplit
         };
 
-        _basic_settings_state = new Dictionary<string, bool>();
-        _custom_settings_state = new Dictionary<string, bool>();
+        _basic_settings_state = [];
+        _custom_settings_state = [];
     }
 
     public ComponentSettings(string scriptPath)

--- a/src/LiveSplit.ScriptableAutoSplit/ComponentSettings.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ComponentSettings.cs
@@ -43,7 +43,7 @@ public partial class ComponentSettings : UserControl
 
         ScriptPath = string.Empty;
 
-        this.txtScriptPath.DataBindings.Add("Text", this, "ScriptPath", false,
+        txtScriptPath.DataBindings.Add("Text", this, "ScriptPath", false,
             DataSourceUpdateMode.OnPropertyChanged);
 
         SetGameVersion(null);
@@ -100,7 +100,7 @@ public partial class ComponentSettings : UserControl
 
     public void SetGameVersion(string version)
     {
-        this.lblGameVersion.Text = string.IsNullOrEmpty(version) ? "" : "Game Version: " + version;
+        lblGameVersion.Text = string.IsNullOrEmpty(version) ? "" : "Game Version: " + version;
     }
 
     /// <summary>
@@ -128,8 +128,8 @@ public partial class ComponentSettings : UserControl
             _custom_settings_state.Clear();
         }
 
-        this.treeCustomSettings.BeginUpdate();
-        this.treeCustomSettings.Nodes.Clear();
+        treeCustomSettings.BeginUpdate();
+        treeCustomSettings.Nodes.Clear();
 
         var values = new Dictionary<string, bool>();
 
@@ -148,19 +148,19 @@ public partial class ComponentSettings : UserControl
             {
                 Tag = setting,
                 Checked = value,
-                ContextMenuStrip = this.treeContextMenu2,
+                ContextMenuStrip = treeContextMenu2,
                 ToolTipText = setting.ToolTip
             };
             setting.Value = value;
 
             if (setting.Parent == null)
             {
-                this.treeCustomSettings.Nodes.Add(node);
+                treeCustomSettings.Nodes.Add(node);
             }
             else if (flat.ContainsKey(setting.Parent))
             {
                 flat[setting.Parent].Nodes.Add(node);
-                flat[setting.Parent].ContextMenuStrip = this.treeContextMenu;
+                flat[setting.Parent].ContextMenuStrip = treeContextMenu;
             }
 
             flat.Add(setting.Id, node);
@@ -189,9 +189,9 @@ public partial class ComponentSettings : UserControl
         treeCustomSettings.EndUpdate();
 
         // Scroll up to the top
-        if (this.treeCustomSettings.Nodes.Count > 0)
+        if (treeCustomSettings.Nodes.Count > 0)
         {
-            this.treeCustomSettings.Nodes[0].EnsureVisible();
+            treeCustomSettings.Nodes[0].EnsureVisible();
         }
 
         UpdateCustomSettingsVisibility();
@@ -313,12 +313,12 @@ public partial class ComponentSettings : UserControl
 
     private void UpdateCustomSettingsVisibility()
     {
-        bool show = this.treeCustomSettings.GetNodeCount(false) > 0;
-        this.treeCustomSettings.Visible = show;
-        this.btnResetToDefault.Visible = show;
-        this.btnCheckAll.Visible = show;
-        this.btnUncheckAll.Visible = show;
-        this.labelCustomSettings.Visible = show;
+        bool show = treeCustomSettings.GetNodeCount(false) > 0;
+        treeCustomSettings.Visible = show;
+        btnResetToDefault.Visible = show;
+        btnCheckAll.Visible = show;
+        btnUncheckAll.Visible = show;
+        labelCustomSettings.Visible = show;
     }
 
     /// <summary>
@@ -346,7 +346,7 @@ public partial class ComponentSettings : UserControl
     /// 
     private void UpdateNodesCheckedState(Func<ASLSetting, bool> func, TreeNodeCollection nodes = null)
     {
-        nodes ??= this.treeCustomSettings.Nodes;
+        nodes ??= treeCustomSettings.Nodes;
 
         UpdateNodesInTree(node =>
         {
@@ -430,7 +430,7 @@ public partial class ComponentSettings : UserControl
 
         if (dialog.ShowDialog() == DialogResult.OK)
         {
-            ScriptPath = this.txtScriptPath.Text = dialog.FileName;
+            ScriptPath = txtScriptPath.Text = dialog.FileName;
         }
     }
 
@@ -492,61 +492,61 @@ public partial class ComponentSettings : UserControl
     private void settingsTree_NodeMouseClick(object sender, TreeNodeMouseClickEventArgs e)
     {
         // Select clicked node (not only with left-click) for use with context menu
-        this.treeCustomSettings.SelectedNode = e.Node;
+        treeCustomSettings.SelectedNode = e.Node;
     }
 
     private void cmiCheckBranch_Click(object sender, EventArgs e)
     {
-        UpdateNodesCheckedState(s => true, this.treeCustomSettings.SelectedNode.Nodes);
-        UpdateNodeCheckedState(s => true, this.treeCustomSettings.SelectedNode);
+        UpdateNodesCheckedState(s => true, treeCustomSettings.SelectedNode.Nodes);
+        UpdateNodeCheckedState(s => true, treeCustomSettings.SelectedNode);
     }
 
     private void cmiUncheckBranch_Click(object sender, EventArgs e)
     {
-        UpdateNodesCheckedState(s => false, this.treeCustomSettings.SelectedNode.Nodes);
-        UpdateNodeCheckedState(s => false, this.treeCustomSettings.SelectedNode);
+        UpdateNodesCheckedState(s => false, treeCustomSettings.SelectedNode.Nodes);
+        UpdateNodeCheckedState(s => false, treeCustomSettings.SelectedNode);
     }
 
     private void cmiResetBranchToDefault_Click(object sender, EventArgs e)
     {
-        UpdateNodesCheckedState(s => s.DefaultValue, this.treeCustomSettings.SelectedNode.Nodes);
-        UpdateNodeCheckedState(s => s.DefaultValue, this.treeCustomSettings.SelectedNode);
+        UpdateNodesCheckedState(s => s.DefaultValue, treeCustomSettings.SelectedNode.Nodes);
+        UpdateNodeCheckedState(s => s.DefaultValue, treeCustomSettings.SelectedNode);
     }
 
     private void cmiExpandBranch_Click(object sender, EventArgs e)
     {
-        this.treeCustomSettings.SelectedNode.ExpandAll();
-        this.treeCustomSettings.SelectedNode.EnsureVisible();
+        treeCustomSettings.SelectedNode.ExpandAll();
+        treeCustomSettings.SelectedNode.EnsureVisible();
     }
 
     private void cmiCollapseBranch_Click(object sender, EventArgs e)
     {
-        this.treeCustomSettings.SelectedNode.Collapse();
-        this.treeCustomSettings.SelectedNode.EnsureVisible();
+        treeCustomSettings.SelectedNode.Collapse();
+        treeCustomSettings.SelectedNode.EnsureVisible();
     }
 
     private void cmiCollapseTreeToSelection_Click(object sender, EventArgs e)
     {
-        TreeNode selected = this.treeCustomSettings.SelectedNode;
-        this.treeCustomSettings.CollapseAll();
-        this.treeCustomSettings.SelectedNode = selected;
+        TreeNode selected = treeCustomSettings.SelectedNode;
+        treeCustomSettings.CollapseAll();
+        treeCustomSettings.SelectedNode = selected;
         selected.EnsureVisible();
     }
 
     private void cmiExpandTree_Click(object sender, EventArgs e)
     {
-        this.treeCustomSettings.ExpandAll();
-        this.treeCustomSettings.SelectedNode.EnsureVisible();
+        treeCustomSettings.ExpandAll();
+        treeCustomSettings.SelectedNode.EnsureVisible();
     }
 
     private void cmiCollapseTree_Click(object sender, EventArgs e)
     {
-        this.treeCustomSettings.CollapseAll();
+        treeCustomSettings.CollapseAll();
     }
 
     private void cmiResetSettingToDefault_Click(object sender, EventArgs e)
     {
-        UpdateNodeCheckedState(s => s.DefaultValue, this.treeCustomSettings.SelectedNode);
+        UpdateNodeCheckedState(s => s.DefaultValue, treeCustomSettings.SelectedNode);
     }
 }
 

--- a/src/LiveSplit.ScriptableAutoSplit/ComponentSettings.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ComponentSettings.cs
@@ -37,7 +37,6 @@ public partial class ComponentSettings : UserControl
     // Custom settings
     private Dictionary<string, bool> _custom_settings_state;
 
-
     public ComponentSettings()
     {
         InitializeComponent();
@@ -89,7 +88,10 @@ public partial class ComponentSettings : UserControl
         if (!element.IsEmpty)
         {
             if (!_ignore_next_path_setting)
+            {
                 ScriptPath = SettingsHelper.ParseString(element["ScriptPath"], string.Empty);
+            }
+
             _ignore_next_path_setting = false;
             ParseBasicSettingsFromXml(element);
             ParseCustomSettingsFromXml(element);
@@ -138,7 +140,9 @@ public partial class ComponentSettings : UserControl
         {
             var value = setting.Value;
             if (_custom_settings_state.ContainsKey(setting.Id))
+            {
                 value = _custom_settings_state[setting.Id];
+            }
 
             var node = new TreeNode(setting.Label)
             {
@@ -177,19 +181,22 @@ public partial class ComponentSettings : UserControl
         // be empty because the script failed to load, which can happen frequently when working
         // on ASL scripts)
         if (script_loaded)
+        {
             _custom_settings_state = values;
+        }
 
         treeCustomSettings.ExpandAll();
         treeCustomSettings.EndUpdate();
 
         // Scroll up to the top
         if (this.treeCustomSettings.Nodes.Count > 0)
+        {
             this.treeCustomSettings.Nodes[0].EnsureVisible();
+        }
 
         UpdateCustomSettingsVisibility();
         InitBasicSettings(settings);
     }
-
 
     private void AppendBasicSettingsToXml(XmlDocument document, XmlNode settings_node)
     {
@@ -232,7 +239,9 @@ public partial class ComponentSettings : UserControl
 
                 // If component is not enabled, don't check setting
                 if (item.Value.Enabled)
+                {
                     item.Value.Checked = value;
+                }
 
                 _basic_settings_state[item.Key.ToLower()] = value;
             }
@@ -252,7 +261,9 @@ public partial class ComponentSettings : UserControl
             foreach (XmlElement element in custom_settings_node.ChildNodes)
             {
                 if (element.Name != "Setting")
+                {
                     continue;
+                }
 
                 string id = element.Attributes["id"].Value;
                 string type = element.Attributes["type"].Value;
@@ -284,7 +295,9 @@ public partial class ComponentSettings : UserControl
                 var value = setting.Value;
 
                 if (_basic_settings_state.ContainsKey(name))
+                {
                     value = _basic_settings_state[name];
+                }
 
                 checkbox.Checked = value;
                 setting.Value = value;
@@ -319,7 +332,9 @@ public partial class ComponentSettings : UserControl
         {
             bool include_child_nodes = func(node);
             if (include_child_nodes)
+            {
                 UpdateNodesInTree(func, node.Nodes);
+            }
         }
     }
 
@@ -332,7 +347,9 @@ public partial class ComponentSettings : UserControl
     private void UpdateNodesCheckedState(Func<ASLSetting, bool> func, TreeNodeCollection nodes = null)
     {
         if (nodes == null)
+        {
             nodes = this.treeCustomSettings.Nodes;
+        }
 
         UpdateNodesInTree(node =>
         {
@@ -340,7 +357,9 @@ public partial class ComponentSettings : UserControl
             bool check = func(setting);
 
             if (node.Checked != check)
+            {
                 node.Checked = check;
+            }
 
             return true;
         }, nodes);
@@ -354,14 +373,18 @@ public partial class ComponentSettings : UserControl
     private void UpdateNodesCheckedState(Dictionary<string, bool> setting_values, TreeNodeCollection nodes = null)
     {
         if (setting_values == null)
+        {
             return;
+        }
 
         UpdateNodesCheckedState(setting =>
         {
             string id = setting.Id;
 
             if (setting_values.ContainsKey(id))
+            {
                 return setting_values[id];
+            }
 
             return setting.Value;
         }, nodes);
@@ -373,7 +396,9 @@ public partial class ComponentSettings : UserControl
         bool check = func(setting);
 
         if (node.Checked != check)
+        {
             node.Checked = check;
+        }
     }
 
     /// <summary>
@@ -392,7 +417,6 @@ public partial class ComponentSettings : UserControl
         }
     }
 
-
     // Events
 
     private void btnSelectFile_Click(object sender, EventArgs e)
@@ -408,7 +432,9 @@ public partial class ComponentSettings : UserControl
         }
 
         if (dialog.ShowDialog() == DialogResult.OK)
+        {
             ScriptPath = this.txtScriptPath.Text = dialog.FileName;
+        }
     }
 
     // Basic Setting checked/unchecked
@@ -463,7 +489,6 @@ public partial class ComponentSettings : UserControl
     {
         UpdateNodesCheckedState(s => s.DefaultValue);
     }
-
 
     // Custom Settings Context Menu Events
 

--- a/src/LiveSplit.ScriptableAutoSplit/ComponentSettings.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ComponentSettings.cs
@@ -138,7 +138,7 @@ public partial class ComponentSettings : UserControl
 
         foreach (ASLSetting setting in settings.OrderedSettings)
         {
-            var value = setting.Value;
+            bool value = setting.Value;
             if (_custom_settings_state.ContainsKey(setting.Id))
             {
                 value = _custom_settings_state[setting.Id];
@@ -168,7 +168,7 @@ public partial class ComponentSettings : UserControl
         }
 
         // Gray out deactivated nodes after all have been added
-        foreach (var item in flat)
+        foreach (KeyValuePair<string, TreeNode> item in flat)
         {
             if (!item.Value.Checked)
             {
@@ -200,11 +200,11 @@ public partial class ComponentSettings : UserControl
 
     private void AppendBasicSettingsToXml(XmlDocument document, XmlNode settings_node)
     {
-        foreach (var item in _basic_settings)
+        foreach (KeyValuePair<string, CheckBox> item in _basic_settings)
         {
             if (_basic_settings_state.ContainsKey(item.Key.ToLower()))
             {
-                var value = _basic_settings_state[item.Key.ToLower()];
+                bool value = _basic_settings_state[item.Key.ToLower()];
                 settings_node.AppendChild(SettingsHelper.ToElement(document, item.Key, value));
             }
         }
@@ -214,7 +214,7 @@ public partial class ComponentSettings : UserControl
     {
         XmlElement asl_parent = document.CreateElement("CustomSettings");
 
-        foreach (var setting in _custom_settings_state)
+        foreach (KeyValuePair<string, bool> setting in _custom_settings_state)
         {
             XmlElement element = SettingsHelper.ToElement(document, "Setting", setting.Value);
             XmlAttribute id = SettingsHelper.ToAttribute(document, "id", setting.Key);
@@ -231,11 +231,11 @@ public partial class ComponentSettings : UserControl
 
     private void ParseBasicSettingsFromXml(XmlElement element)
     {
-        foreach (var item in _basic_settings)
+        foreach (KeyValuePair<string, CheckBox> item in _basic_settings)
         {
             if (element[item.Key] != null)
             {
-                var value = bool.Parse(element[item.Key].InnerText);
+                bool value = bool.Parse(element[item.Key].InnerText);
 
                 // If component is not enabled, don't check setting
                 if (item.Value.Enabled)
@@ -282,7 +282,7 @@ public partial class ComponentSettings : UserControl
 
     private void InitBasicSettings(ASLSettings settings)
     {
-        foreach (var item in _basic_settings)
+        foreach (KeyValuePair<string, CheckBox> item in _basic_settings)
         {
             string name = item.Key.ToLower();
             CheckBox checkbox = item.Value;
@@ -292,7 +292,7 @@ public partial class ComponentSettings : UserControl
                 ASLSetting setting = settings.BasicSettings[name];
                 checkbox.Enabled = true;
                 checkbox.Tag = setting;
-                var value = setting.Value;
+                bool value = setting.Value;
 
                 if (_basic_settings_state.ContainsKey(name))
                 {
@@ -454,7 +454,7 @@ public partial class ComponentSettings : UserControl
     private void settingsTree_AfterCheck(object sender, TreeViewEventArgs e)
     {
         // Update value in the ASLSetting object, which also changes it in the ASL script
-        ASLSetting setting = (ASLSetting)e.Node.Tag;
+        var setting = (ASLSetting)e.Node.Tag;
         setting.Value = e.Node.Checked;
         _custom_settings_state[setting.Id] = setting.Value;
 
@@ -563,8 +563,8 @@ internal class NewTreeView : TreeView
     {
         if (m.Msg == 0x203) // identified double click
         {
-            var local_pos = PointToClient(Cursor.Position);
-            var hit_test_info = HitTest(local_pos);
+            Point local_pos = PointToClient(Cursor.Position);
+            TreeViewHitTestInfo hit_test_info = HitTest(local_pos);
 
             if (hit_test_info.Location == TreeViewHitTestLocations.StateImage)
             {

--- a/src/LiveSplit.ScriptableAutoSplit/ComponentSettings.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ComponentSettings.cs
@@ -346,10 +346,7 @@ public partial class ComponentSettings : UserControl
     /// 
     private void UpdateNodesCheckedState(Func<ASLSetting, bool> func, TreeNodeCollection nodes = null)
     {
-        if (nodes == null)
-        {
-            nodes = this.treeCustomSettings.Nodes;
-        }
+        nodes ??= this.treeCustomSettings.Nodes;
 
         UpdateNodesInTree(node =>
         {

--- a/src/LiveSplit.ScriptableAutoSplit/ComponentSettings.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ComponentSettings.cs
@@ -1,553 +1,559 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.IO;
 using System.Windows.Forms;
 using System.Xml;
+
 using LiveSplit.ASL;
-using System.IO;
 
-namespace LiveSplit.UI.Components
+namespace LiveSplit.UI.Components;
+
+public partial class ComponentSettings : UserControl
 {
-    public partial class ComponentSettings : UserControl
+    public string ScriptPath { get; set; }
+
+    // if true, next path loaded from settings will be ignored
+    private bool _ignore_next_path_setting;
+
+    private Dictionary<string, CheckBox> _basic_settings;
+
+    // Save the state of settings independant of actual ASLSetting objects
+    // or the actual GUI components (checkboxes). This is used to restore
+    // the state when the script is first loaded (because settings are
+    // loaded before the script) or reloaded.
+    //
+    // State is synchronized with the ASLSettings when a script is
+    // successfully loaded, as well as when the checkboxes/tree check
+    // state is changed by the user or program. It is also updated
+    // when loaded from XML.
+    //
+    // State is stored from the current script, or the last loaded script
+    // if no script is currently loaded.
+
+    // Start/Reset/Split checkboxes
+    private Dictionary<string, bool> _basic_settings_state;
+
+    // Custom settings
+    private Dictionary<string, bool> _custom_settings_state;
+
+
+    public ComponentSettings()
     {
-        public string ScriptPath { get; set; }
+        InitializeComponent();
 
-        // if true, next path loaded from settings will be ignored
-        private bool _ignore_next_path_setting;
+        ScriptPath = string.Empty;
 
-        private Dictionary<string, CheckBox> _basic_settings;
+        this.txtScriptPath.DataBindings.Add("Text", this, "ScriptPath", false,
+            DataSourceUpdateMode.OnPropertyChanged);
 
-        // Save the state of settings independant of actual ASLSetting objects
-        // or the actual GUI components (checkboxes). This is used to restore
-        // the state when the script is first loaded (because settings are
-        // loaded before the script) or reloaded.
-        //
-        // State is synchronized with the ASLSettings when a script is
-        // successfully loaded, as well as when the checkboxes/tree check
-        // state is changed by the user or program. It is also updated
-        // when loaded from XML.
-        //
-        // State is stored from the current script, or the last loaded script
-        // if no script is currently loaded.
+        SetGameVersion(null);
+        UpdateCustomSettingsVisibility();
 
-        // Start/Reset/Split checkboxes
-        private Dictionary<string, bool> _basic_settings_state;
-
-        // Custom settings
-        private Dictionary<string, bool> _custom_settings_state;
-
-
-        public ComponentSettings()
+        _basic_settings = new Dictionary<string, CheckBox>
         {
-            InitializeComponent();
+            // Capitalized names for saving it in XML.
+            ["Start"] = checkboxStart,
+            ["Reset"] = checkboxReset,
+            ["Split"] = checkboxSplit
+        };
 
-            ScriptPath = string.Empty;
+        _basic_settings_state = new Dictionary<string, bool>();
+        _custom_settings_state = new Dictionary<string, bool>();
+    }
 
-            this.txtScriptPath.DataBindings.Add("Text", this, "ScriptPath", false,
-                DataSourceUpdateMode.OnPropertyChanged);
+    public ComponentSettings(string scriptPath)
+        : this()
+    {
+        ScriptPath = scriptPath;
+        _ignore_next_path_setting = true;
+    }
 
-            SetGameVersion(null);
-            UpdateCustomSettingsVisibility();
+    public XmlNode GetSettings(XmlDocument document)
+    {
+        XmlElement settings_node = document.CreateElement("Settings");
 
-            _basic_settings = new Dictionary<string, CheckBox> {
-                // Capitalized names for saving it in XML.
-                ["Start"] = checkboxStart,
-                ["Reset"] = checkboxReset,
-                ["Split"] = checkboxSplit
+        settings_node.AppendChild(SettingsHelper.ToElement(document, "Version", "1.5"));
+        settings_node.AppendChild(SettingsHelper.ToElement(document, "ScriptPath", ScriptPath));
+        AppendBasicSettingsToXml(document, settings_node);
+        AppendCustomSettingsToXml(document, settings_node);
+
+        return settings_node;
+    }
+
+    // Loads the settings of this component from Xml. This might happen more than once
+    // (e.g. when the settings dialog is cancelled, to restore previous settings).
+    public void SetSettings(XmlNode settings)
+    {
+        var element = (XmlElement)settings;
+        if (!element.IsEmpty)
+        {
+            if (!_ignore_next_path_setting)
+                ScriptPath = SettingsHelper.ParseString(element["ScriptPath"], string.Empty);
+            _ignore_next_path_setting = false;
+            ParseBasicSettingsFromXml(element);
+            ParseCustomSettingsFromXml(element);
+        }
+    }
+
+    public void SetGameVersion(string version)
+    {
+        this.lblGameVersion.Text = string.IsNullOrEmpty(version) ? "" : "Game Version: " + version;
+    }
+
+    /// <summary>
+    /// Populates the component with the settings defined in the ASL script.
+    /// </summary>
+    public void SetASLSettings(ASLSettings settings)
+    {
+        InitASLSettings(settings, true);
+    }
+
+    /// <summary>
+    /// Empties the GUI of all settings (but still keeps settings state
+    /// for the next script load).
+    /// </summary>
+    public void ResetASLSettings()
+    {
+        InitASLSettings(new ASLSettings(), false);
+    }
+
+    private void InitASLSettings(ASLSettings settings, bool script_loaded)
+    {
+        if (string.IsNullOrWhiteSpace(ScriptPath))
+        {
+            _basic_settings_state.Clear();
+            _custom_settings_state.Clear();
+        }
+
+        this.treeCustomSettings.BeginUpdate();
+        this.treeCustomSettings.Nodes.Clear();
+
+        var values = new Dictionary<string, bool>();
+
+        // Store temporary for easier lookup of parent nodes
+        var flat = new Dictionary<string, TreeNode>();
+
+        foreach (ASLSetting setting in settings.OrderedSettings)
+        {
+            var value = setting.Value;
+            if (_custom_settings_state.ContainsKey(setting.Id))
+                value = _custom_settings_state[setting.Id];
+
+            var node = new TreeNode(setting.Label)
+            {
+                Tag = setting,
+                Checked = value,
+                ContextMenuStrip = this.treeContextMenu2,
+                ToolTipText = setting.ToolTip
             };
+            setting.Value = value;
 
-            _basic_settings_state = new Dictionary<string, bool>();
-            _custom_settings_state = new Dictionary<string, bool>();
-        }
-
-        public ComponentSettings(string scriptPath)
-            : this()
-        {
-            ScriptPath = scriptPath;
-            _ignore_next_path_setting = true;
-        }
-
-        public XmlNode GetSettings(XmlDocument document)
-        {
-            XmlElement settings_node = document.CreateElement("Settings");
-
-            settings_node.AppendChild(SettingsHelper.ToElement(document, "Version", "1.5"));
-            settings_node.AppendChild(SettingsHelper.ToElement(document, "ScriptPath", ScriptPath));
-            AppendBasicSettingsToXml(document, settings_node);
-            AppendCustomSettingsToXml(document, settings_node);
-
-            return settings_node;
-        }
-
-        // Loads the settings of this component from Xml. This might happen more than once
-        // (e.g. when the settings dialog is cancelled, to restore previous settings).
-        public void SetSettings(XmlNode settings)
-        {
-            var element = (XmlElement)settings;
-            if (!element.IsEmpty)
+            if (setting.Parent == null)
             {
-                if (!_ignore_next_path_setting)
-                    ScriptPath = SettingsHelper.ParseString(element["ScriptPath"], string.Empty);
-                _ignore_next_path_setting = false;
-                ParseBasicSettingsFromXml(element);
-                ParseCustomSettingsFromXml(element);
+                this.treeCustomSettings.Nodes.Add(node);
+            }
+            else if (flat.ContainsKey(setting.Parent))
+            {
+                flat[setting.Parent].Nodes.Add(node);
+                flat[setting.Parent].ContextMenuStrip = this.treeContextMenu;
+            }
+
+            flat.Add(setting.Id, node);
+            values.Add(setting.Id, value);
+        }
+
+        // Gray out deactivated nodes after all have been added
+        foreach (var item in flat)
+        {
+            if (!item.Value.Checked)
+            {
+                UpdateGrayedOut(item.Value);
             }
         }
 
-        public void SetGameVersion(string version)
-        {
-            this.lblGameVersion.Text = string.IsNullOrEmpty(version) ? "" : "Game Version: " + version;
-        }
+        // Only if a script was actually loaded, update current state with current ASL settings
+        // (which may be empty if the successfully loaded script has no settings, but shouldn't
+        // be empty because the script failed to load, which can happen frequently when working
+        // on ASL scripts)
+        if (script_loaded)
+            _custom_settings_state = values;
 
-        /// <summary>
-        /// Populates the component with the settings defined in the ASL script.
-        /// </summary>
-        public void SetASLSettings(ASLSettings settings)
-        {
-            InitASLSettings(settings, true);
-        }
+        treeCustomSettings.ExpandAll();
+        treeCustomSettings.EndUpdate();
 
-        /// <summary>
-        /// Empties the GUI of all settings (but still keeps settings state
-        /// for the next script load).
-        /// </summary>
-        public void ResetASLSettings()
-        {
-            InitASLSettings(new ASLSettings(), false);
-        }
+        // Scroll up to the top
+        if (this.treeCustomSettings.Nodes.Count > 0)
+            this.treeCustomSettings.Nodes[0].EnsureVisible();
 
-        private void InitASLSettings(ASLSettings settings, bool script_loaded)
+        UpdateCustomSettingsVisibility();
+        InitBasicSettings(settings);
+    }
+
+
+    private void AppendBasicSettingsToXml(XmlDocument document, XmlNode settings_node)
+    {
+        foreach (var item in _basic_settings)
         {
-            if (string.IsNullOrWhiteSpace(ScriptPath))
+            if (_basic_settings_state.ContainsKey(item.Key.ToLower()))
             {
-                _basic_settings_state.Clear();
-                _custom_settings_state.Clear();
+                var value = _basic_settings_state[item.Key.ToLower()];
+                settings_node.AppendChild(SettingsHelper.ToElement(document, item.Key, value));
             }
+        }
+    }
 
-            this.treeCustomSettings.BeginUpdate();
-            this.treeCustomSettings.Nodes.Clear();
+    private void AppendCustomSettingsToXml(XmlDocument document, XmlNode parent)
+    {
+        XmlElement asl_parent = document.CreateElement("CustomSettings");
 
-            var values = new Dictionary<string, bool>();
+        foreach (var setting in _custom_settings_state)
+        {
+            XmlElement element = SettingsHelper.ToElement(document, "Setting", setting.Value);
+            XmlAttribute id = SettingsHelper.ToAttribute(document, "id", setting.Key);
+            // In case there are other setting types in the future
+            XmlAttribute type = SettingsHelper.ToAttribute(document, "type", "bool");
 
-            // Store temporary for easier lookup of parent nodes
-            var flat = new Dictionary<string, TreeNode>();
+            element.Attributes.Append(id);
+            element.Attributes.Append(type);
+            asl_parent.AppendChild(element);
+        }
 
-            foreach (ASLSetting setting in settings.OrderedSettings)
+        parent.AppendChild(asl_parent);
+    }
+
+    private void ParseBasicSettingsFromXml(XmlElement element)
+    {
+        foreach (var item in _basic_settings)
+        {
+            if (element[item.Key] != null)
             {
+                var value = bool.Parse(element[item.Key].InnerText);
+
+                // If component is not enabled, don't check setting
+                if (item.Value.Enabled)
+                    item.Value.Checked = value;
+
+                _basic_settings_state[item.Key.ToLower()] = value;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Parses custom settings, stores them and updates the checked state of already added tree nodes.
+    /// </summary>
+    /// 
+    private void ParseCustomSettingsFromXml(XmlElement data)
+    {
+        XmlElement custom_settings_node = data["CustomSettings"];
+
+        if (custom_settings_node != null && custom_settings_node.HasChildNodes)
+        {
+            foreach (XmlElement element in custom_settings_node.ChildNodes)
+            {
+                if (element.Name != "Setting")
+                    continue;
+
+                string id = element.Attributes["id"].Value;
+                string type = element.Attributes["type"].Value;
+
+                if (id != null && type == "bool")
+                {
+                    bool value = SettingsHelper.ParseBool(element);
+                    _custom_settings_state[id] = value;
+                }
+            }
+        }
+
+        // Update tree with loaded state (in case the tree is already populated)
+        UpdateNodesCheckedState(_custom_settings_state);
+    }
+
+    private void InitBasicSettings(ASLSettings settings)
+    {
+        foreach (var item in _basic_settings)
+        {
+            string name = item.Key.ToLower();
+            CheckBox checkbox = item.Value;
+
+            if (settings.IsBasicSettingPresent(name))
+            {
+                ASLSetting setting = settings.BasicSettings[name];
+                checkbox.Enabled = true;
+                checkbox.Tag = setting;
                 var value = setting.Value;
-                if (_custom_settings_state.ContainsKey(setting.Id))
-                    value = _custom_settings_state[setting.Id];
 
-                var node = new TreeNode(setting.Label) {
-                    Tag = setting,
-                    Checked = value,
-                    ContextMenuStrip = this.treeContextMenu2,
-                    ToolTipText = setting.ToolTip
-                };
+                if (_basic_settings_state.ContainsKey(name))
+                    value = _basic_settings_state[name];
+
+                checkbox.Checked = value;
                 setting.Value = value;
-
-                if (setting.Parent == null)
-                {
-                    this.treeCustomSettings.Nodes.Add(node);
-                }
-                else if (flat.ContainsKey(setting.Parent))
-                {
-                    flat[setting.Parent].Nodes.Add(node);
-                    flat[setting.Parent].ContextMenuStrip = this.treeContextMenu;
-                }
-
-                flat.Add(setting.Id, node);
-                values.Add(setting.Id, value);
             }
-
-            // Gray out deactivated nodes after all have been added
-            foreach (var item in flat) {
-                if (!item.Value.Checked)
-                {
-                    UpdateGrayedOut(item.Value);
-                }
-            }
-
-            // Only if a script was actually loaded, update current state with current ASL settings
-            // (which may be empty if the successfully loaded script has no settings, but shouldn't
-            // be empty because the script failed to load, which can happen frequently when working
-            // on ASL scripts)
-            if (script_loaded)
-                _custom_settings_state = values;
-
-            treeCustomSettings.ExpandAll();
-            treeCustomSettings.EndUpdate();
-
-            // Scroll up to the top
-            if (this.treeCustomSettings.Nodes.Count > 0)
-                this.treeCustomSettings.Nodes[0].EnsureVisible();
-
-            UpdateCustomSettingsVisibility();
-            InitBasicSettings(settings);
-        }
-
-
-        private void AppendBasicSettingsToXml(XmlDocument document, XmlNode settings_node)
-        {
-            foreach (var item in _basic_settings)
+            else
             {
-                if (_basic_settings_state.ContainsKey(item.Key.ToLower()))
-                {
-                    var value = _basic_settings_state[item.Key.ToLower()];
-                    settings_node.AppendChild(SettingsHelper.ToElement(document, item.Key, value));
-                }
+                checkbox.Tag = null;
+                checkbox.Enabled = false;
+                checkbox.Checked = false;
             }
         }
+    }
 
-        private void AppendCustomSettingsToXml(XmlDocument document, XmlNode parent)
+    private void UpdateCustomSettingsVisibility()
+    {
+        bool show = this.treeCustomSettings.GetNodeCount(false) > 0;
+        this.treeCustomSettings.Visible = show;
+        this.btnResetToDefault.Visible = show;
+        this.btnCheckAll.Visible = show;
+        this.btnUncheckAll.Visible = show;
+        this.labelCustomSettings.Visible = show;
+    }
+
+    /// <summary>
+    /// Generic update on all given nodes and their childnodes, ignoring childnodes for
+    /// nodes where the Func returns false.
+    /// </summary>
+    /// 
+    private void UpdateNodesInTree(Func<TreeNode, bool> func, TreeNodeCollection nodes)
+    {
+        foreach (TreeNode node in nodes)
         {
-            XmlElement asl_parent = document.CreateElement("CustomSettings");
-
-            foreach (var setting in _custom_settings_state)
-            {
-                XmlElement element = SettingsHelper.ToElement(document, "Setting", setting.Value);
-                XmlAttribute id = SettingsHelper.ToAttribute(document, "id", setting.Key);
-                // In case there are other setting types in the future
-                XmlAttribute type = SettingsHelper.ToAttribute(document, "type", "bool");
-
-                element.Attributes.Append(id);
-                element.Attributes.Append(type);
-                asl_parent.AppendChild(element);
-            }
-
-            parent.AppendChild(asl_parent);
+            bool include_child_nodes = func(node);
+            if (include_child_nodes)
+                UpdateNodesInTree(func, node.Nodes);
         }
+    }
 
-        private void ParseBasicSettingsFromXml(XmlElement element)
-        {
-            foreach (var item in _basic_settings)
-            {
-                if (element[item.Key] != null)
-                {
-                    var value = bool.Parse(element[item.Key].InnerText);
+    /// <summary>
+    /// Update the checked state of all given nodes and their childnodes based on the return
+    /// value of the given Func.
+    /// </summary>
+    /// <param name="nodes">If nodes is null, all nodes of the custom settings tree are affected.</param>
+    /// 
+    private void UpdateNodesCheckedState(Func<ASLSetting, bool> func, TreeNodeCollection nodes = null)
+    {
+        if (nodes == null)
+            nodes = this.treeCustomSettings.Nodes;
 
-                    // If component is not enabled, don't check setting
-                    if (item.Value.Enabled)
-                        item.Value.Checked = value;
-
-                    _basic_settings_state[item.Key.ToLower()] = value;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Parses custom settings, stores them and updates the checked state of already added tree nodes.
-        /// </summary>
-        /// 
-        private void ParseCustomSettingsFromXml(XmlElement data)
-        {
-            XmlElement custom_settings_node = data["CustomSettings"];
-
-            if (custom_settings_node != null && custom_settings_node.HasChildNodes)
-            {
-                foreach (XmlElement element in custom_settings_node.ChildNodes)
-                {
-                    if (element.Name != "Setting")
-                        continue;
-
-                    string id = element.Attributes["id"].Value;
-                    string type = element.Attributes["type"].Value;
-
-                    if (id != null && type == "bool")
-                    {
-                        bool value = SettingsHelper.ParseBool(element);
-                        _custom_settings_state[id] = value;
-                    }
-                }
-            }
-
-            // Update tree with loaded state (in case the tree is already populated)
-            UpdateNodesCheckedState(_custom_settings_state);
-        }
-
-        private void InitBasicSettings(ASLSettings settings)
-        {
-            foreach (var item in _basic_settings)
-            {
-                string name = item.Key.ToLower();
-                CheckBox checkbox = item.Value;
-
-                if (settings.IsBasicSettingPresent(name))
-                {
-                    ASLSetting setting = settings.BasicSettings[name];
-                    checkbox.Enabled = true;
-                    checkbox.Tag = setting;
-                    var value = setting.Value;
-
-                    if (_basic_settings_state.ContainsKey(name))
-                        value = _basic_settings_state[name];
-
-                    checkbox.Checked = value;
-                    setting.Value = value;
-                }
-                else
-                {
-                    checkbox.Tag = null;
-                    checkbox.Enabled = false;
-                    checkbox.Checked = false;
-                }
-            }
-        }
-
-        private void UpdateCustomSettingsVisibility()
-        {
-            bool show = this.treeCustomSettings.GetNodeCount(false) > 0;
-            this.treeCustomSettings.Visible = show;
-            this.btnResetToDefault.Visible = show;
-            this.btnCheckAll.Visible = show;
-            this.btnUncheckAll.Visible = show;
-            this.labelCustomSettings.Visible = show;
-        }
-
-        /// <summary>
-        /// Generic update on all given nodes and their childnodes, ignoring childnodes for
-        /// nodes where the Func returns false.
-        /// </summary>
-        /// 
-        private void UpdateNodesInTree(Func<TreeNode, bool> func, TreeNodeCollection nodes)
-        {
-            foreach (TreeNode node in nodes)
-            {
-                bool include_child_nodes = func(node);
-                if (include_child_nodes)
-                    UpdateNodesInTree(func, node.Nodes);
-            }
-        }
-
-        /// <summary>
-        /// Update the checked state of all given nodes and their childnodes based on the return
-        /// value of the given Func.
-        /// </summary>
-        /// <param name="nodes">If nodes is null, all nodes of the custom settings tree are affected.</param>
-        /// 
-        private void UpdateNodesCheckedState(Func<ASLSetting, bool> func, TreeNodeCollection nodes = null)
-        {
-            if (nodes == null)
-                nodes = this.treeCustomSettings.Nodes;
-
-            UpdateNodesInTree(node => {
-                var setting = (ASLSetting)node.Tag;
-                bool check = func(setting);
-
-                if (node.Checked != check)
-                    node.Checked = check;
-
-                return true;
-            }, nodes);
-        }
-
-        /// <summary>
-        /// Update the checked state of all given nodes and their childnodes
-        /// based on a dictionary of setting values.
-        /// </summary>
-        /// 
-        private void UpdateNodesCheckedState(Dictionary<string, bool> setting_values, TreeNodeCollection nodes = null)
-        {
-            if (setting_values == null)
-                return;
-
-            UpdateNodesCheckedState(setting => {
-                string id = setting.Id;
-
-                if (setting_values.ContainsKey(id))
-                    return setting_values[id];
-
-                return setting.Value;
-            }, nodes);
-        }
-
-        private void UpdateNodeCheckedState(Func<ASLSetting, bool> func, TreeNode node)
+        UpdateNodesInTree(node =>
         {
             var setting = (ASLSetting)node.Tag;
             bool check = func(setting);
 
             if (node.Checked != check)
                 node.Checked = check;
-        }
 
-        /// <summary>
-        /// If the given node is unchecked, grays out all childnodes.
-        /// </summary>
-        private void UpdateGrayedOut(TreeNode node)
-        {
-            // Only change color of childnodes if this node isn't already grayed out
-            if (node.ForeColor != SystemColors.GrayText)
-            {
-                UpdateNodesInTree(n => {
-                    n.ForeColor = node.Checked ? SystemColors.WindowText : SystemColors.GrayText;
-                    return n.Checked || !node.Checked;
-                }, node.Nodes);
-            }
-        }
-
-
-        // Events
-
-        private void btnSelectFile_Click(object sender, EventArgs e)
-        {
-            var dialog = new OpenFileDialog()
-            {
-                Filter = "Auto Split Script (*.asl)|*.asl|All Files (*.*)|*.*"
-            };
-            if (File.Exists(ScriptPath))
-            {
-                dialog.InitialDirectory = Path.GetDirectoryName(ScriptPath);
-                dialog.FileName = Path.GetFileName(ScriptPath);
-            }
-
-            if (dialog.ShowDialog() == DialogResult.OK)
-                ScriptPath = this.txtScriptPath.Text = dialog.FileName;
-        }
-
-        // Basic Setting checked/unchecked
-        //
-        // This detects both changes made by the user and by the program, so this should
-        // change the state in _basic_settings_state fine as well.
-        private void methodCheckbox_CheckedChanged(object sender, EventArgs e)
-        {
-            var checkbox = (CheckBox)sender;
-            var setting = (ASLSetting)checkbox.Tag;
-
-            if (setting != null)
-            {
-                setting.Value = checkbox.Checked;
-                _basic_settings_state[setting.Id] = setting.Value;
-            }
-        }
-
-        // Custom Setting checked/unchecked (only after initially building the tree)
-        private void settingsTree_AfterCheck(object sender, TreeViewEventArgs e)
-        {
-            // Update value in the ASLSetting object, which also changes it in the ASL script
-            ASLSetting setting = (ASLSetting)e.Node.Tag;
-            setting.Value = e.Node.Checked;
-            _custom_settings_state[setting.Id] = setting.Value;
-
-            UpdateGrayedOut(e.Node);
-        }
-
-        private void settingsTree_BeforeCheck(object sender, TreeViewCancelEventArgs e)
-        {
-            // Confirm that the user initiated the selection
-            if (e.Action != TreeViewAction.Unknown)
-            {
-                e.Cancel = e.Node.ForeColor == SystemColors.GrayText;
-            }
-        }
-
-        // Custom Settings Button Events
-
-        private void btnCheckAll_Click(object sender, EventArgs e)
-        {
-            UpdateNodesCheckedState(s => true);
-        }
-
-        private void btnUncheckAll_Click(object sender, EventArgs e)
-        {
-            UpdateNodesCheckedState(s => false);
-        }
-
-        private void btnResetToDefault_Click(object sender, EventArgs e)
-        {
-            UpdateNodesCheckedState(s => s.DefaultValue);
-        }
-
-
-        // Custom Settings Context Menu Events
-
-        private void settingsTree_NodeMouseClick(object sender, TreeNodeMouseClickEventArgs e)
-        {
-            // Select clicked node (not only with left-click) for use with context menu
-            this.treeCustomSettings.SelectedNode = e.Node;
-        }
-
-        private void cmiCheckBranch_Click(object sender, EventArgs e)
-        {
-            UpdateNodesCheckedState(s => true, this.treeCustomSettings.SelectedNode.Nodes);
-            UpdateNodeCheckedState(s => true, this.treeCustomSettings.SelectedNode);
-        }
-
-        private void cmiUncheckBranch_Click(object sender, EventArgs e)
-        {
-            UpdateNodesCheckedState(s => false, this.treeCustomSettings.SelectedNode.Nodes);
-            UpdateNodeCheckedState(s => false, this.treeCustomSettings.SelectedNode);
-        }
-
-        private void cmiResetBranchToDefault_Click(object sender, EventArgs e)
-        {
-            UpdateNodesCheckedState(s => s.DefaultValue, this.treeCustomSettings.SelectedNode.Nodes);
-            UpdateNodeCheckedState(s => s.DefaultValue, this.treeCustomSettings.SelectedNode);
-        }
-
-        private void cmiExpandBranch_Click(object sender, EventArgs e)
-        {
-            this.treeCustomSettings.SelectedNode.ExpandAll();
-            this.treeCustomSettings.SelectedNode.EnsureVisible();
-        }
-
-        private void cmiCollapseBranch_Click(object sender, EventArgs e)
-        {
-            this.treeCustomSettings.SelectedNode.Collapse();
-            this.treeCustomSettings.SelectedNode.EnsureVisible();
-        }
-
-        private void cmiCollapseTreeToSelection_Click(object sender, EventArgs e)
-        {
-            TreeNode selected = this.treeCustomSettings.SelectedNode;
-            this.treeCustomSettings.CollapseAll();
-            this.treeCustomSettings.SelectedNode = selected;
-            selected.EnsureVisible();
-        }
-
-        private void cmiExpandTree_Click(object sender, EventArgs e)
-        {
-            this.treeCustomSettings.ExpandAll();
-            this.treeCustomSettings.SelectedNode.EnsureVisible();
-        }
-
-        private void cmiCollapseTree_Click(object sender, EventArgs e)
-        {
-            this.treeCustomSettings.CollapseAll();
-        }
-
-        private void cmiResetSettingToDefault_Click(object sender, EventArgs e)
-        {
-            UpdateNodeCheckedState(s => s.DefaultValue, this.treeCustomSettings.SelectedNode);
-        }
+            return true;
+        }, nodes);
     }
 
     /// <summary>
-    /// TreeView with fixed double-clicking on checkboxes.
+    /// Update the checked state of all given nodes and their childnodes
+    /// based on a dictionary of setting values.
     /// </summary>
     /// 
-    /// See also:
-    /// http://stackoverflow.com/questions/17356976/treeview-with-checkboxes-not-processing-clicks-correctly
-    /// http://stackoverflow.com/questions/14647216/c-sharp-treeview-ignore-double-click-only-at-checkbox
-    class NewTreeView : TreeView
+    private void UpdateNodesCheckedState(Dictionary<string, bool> setting_values, TreeNodeCollection nodes = null)
     {
-        protected override void WndProc(ref Message m)
+        if (setting_values == null)
+            return;
+
+        UpdateNodesCheckedState(setting =>
         {
-            if (m.Msg == 0x203) // identified double click
-            {
-                var local_pos = PointToClient(Cursor.Position);
-                var hit_test_info = HitTest(local_pos);
+            string id = setting.Id;
 
-                if (hit_test_info.Location == TreeViewHitTestLocations.StateImage)
-                {
-                    m.Msg = 0x201; // if checkbox was clicked, turn into single click
-                }
+            if (setting_values.ContainsKey(id))
+                return setting_values[id];
 
-                base.WndProc(ref m);
-            }
-            else
+            return setting.Value;
+        }, nodes);
+    }
+
+    private void UpdateNodeCheckedState(Func<ASLSetting, bool> func, TreeNode node)
+    {
+        var setting = (ASLSetting)node.Tag;
+        bool check = func(setting);
+
+        if (node.Checked != check)
+            node.Checked = check;
+    }
+
+    /// <summary>
+    /// If the given node is unchecked, grays out all childnodes.
+    /// </summary>
+    private void UpdateGrayedOut(TreeNode node)
+    {
+        // Only change color of childnodes if this node isn't already grayed out
+        if (node.ForeColor != SystemColors.GrayText)
+        {
+            UpdateNodesInTree(n =>
             {
-                base.WndProc(ref m);
+                n.ForeColor = node.Checked ? SystemColors.WindowText : SystemColors.GrayText;
+                return n.Checked || !node.Checked;
+            }, node.Nodes);
+        }
+    }
+
+
+    // Events
+
+    private void btnSelectFile_Click(object sender, EventArgs e)
+    {
+        var dialog = new OpenFileDialog()
+        {
+            Filter = "Auto Split Script (*.asl)|*.asl|All Files (*.*)|*.*"
+        };
+        if (File.Exists(ScriptPath))
+        {
+            dialog.InitialDirectory = Path.GetDirectoryName(ScriptPath);
+            dialog.FileName = Path.GetFileName(ScriptPath);
+        }
+
+        if (dialog.ShowDialog() == DialogResult.OK)
+            ScriptPath = this.txtScriptPath.Text = dialog.FileName;
+    }
+
+    // Basic Setting checked/unchecked
+    //
+    // This detects both changes made by the user and by the program, so this should
+    // change the state in _basic_settings_state fine as well.
+    private void methodCheckbox_CheckedChanged(object sender, EventArgs e)
+    {
+        var checkbox = (CheckBox)sender;
+        var setting = (ASLSetting)checkbox.Tag;
+
+        if (setting != null)
+        {
+            setting.Value = checkbox.Checked;
+            _basic_settings_state[setting.Id] = setting.Value;
+        }
+    }
+
+    // Custom Setting checked/unchecked (only after initially building the tree)
+    private void settingsTree_AfterCheck(object sender, TreeViewEventArgs e)
+    {
+        // Update value in the ASLSetting object, which also changes it in the ASL script
+        ASLSetting setting = (ASLSetting)e.Node.Tag;
+        setting.Value = e.Node.Checked;
+        _custom_settings_state[setting.Id] = setting.Value;
+
+        UpdateGrayedOut(e.Node);
+    }
+
+    private void settingsTree_BeforeCheck(object sender, TreeViewCancelEventArgs e)
+    {
+        // Confirm that the user initiated the selection
+        if (e.Action != TreeViewAction.Unknown)
+        {
+            e.Cancel = e.Node.ForeColor == SystemColors.GrayText;
+        }
+    }
+
+    // Custom Settings Button Events
+
+    private void btnCheckAll_Click(object sender, EventArgs e)
+    {
+        UpdateNodesCheckedState(s => true);
+    }
+
+    private void btnUncheckAll_Click(object sender, EventArgs e)
+    {
+        UpdateNodesCheckedState(s => false);
+    }
+
+    private void btnResetToDefault_Click(object sender, EventArgs e)
+    {
+        UpdateNodesCheckedState(s => s.DefaultValue);
+    }
+
+
+    // Custom Settings Context Menu Events
+
+    private void settingsTree_NodeMouseClick(object sender, TreeNodeMouseClickEventArgs e)
+    {
+        // Select clicked node (not only with left-click) for use with context menu
+        this.treeCustomSettings.SelectedNode = e.Node;
+    }
+
+    private void cmiCheckBranch_Click(object sender, EventArgs e)
+    {
+        UpdateNodesCheckedState(s => true, this.treeCustomSettings.SelectedNode.Nodes);
+        UpdateNodeCheckedState(s => true, this.treeCustomSettings.SelectedNode);
+    }
+
+    private void cmiUncheckBranch_Click(object sender, EventArgs e)
+    {
+        UpdateNodesCheckedState(s => false, this.treeCustomSettings.SelectedNode.Nodes);
+        UpdateNodeCheckedState(s => false, this.treeCustomSettings.SelectedNode);
+    }
+
+    private void cmiResetBranchToDefault_Click(object sender, EventArgs e)
+    {
+        UpdateNodesCheckedState(s => s.DefaultValue, this.treeCustomSettings.SelectedNode.Nodes);
+        UpdateNodeCheckedState(s => s.DefaultValue, this.treeCustomSettings.SelectedNode);
+    }
+
+    private void cmiExpandBranch_Click(object sender, EventArgs e)
+    {
+        this.treeCustomSettings.SelectedNode.ExpandAll();
+        this.treeCustomSettings.SelectedNode.EnsureVisible();
+    }
+
+    private void cmiCollapseBranch_Click(object sender, EventArgs e)
+    {
+        this.treeCustomSettings.SelectedNode.Collapse();
+        this.treeCustomSettings.SelectedNode.EnsureVisible();
+    }
+
+    private void cmiCollapseTreeToSelection_Click(object sender, EventArgs e)
+    {
+        TreeNode selected = this.treeCustomSettings.SelectedNode;
+        this.treeCustomSettings.CollapseAll();
+        this.treeCustomSettings.SelectedNode = selected;
+        selected.EnsureVisible();
+    }
+
+    private void cmiExpandTree_Click(object sender, EventArgs e)
+    {
+        this.treeCustomSettings.ExpandAll();
+        this.treeCustomSettings.SelectedNode.EnsureVisible();
+    }
+
+    private void cmiCollapseTree_Click(object sender, EventArgs e)
+    {
+        this.treeCustomSettings.CollapseAll();
+    }
+
+    private void cmiResetSettingToDefault_Click(object sender, EventArgs e)
+    {
+        UpdateNodeCheckedState(s => s.DefaultValue, this.treeCustomSettings.SelectedNode);
+    }
+}
+
+/// <summary>
+/// TreeView with fixed double-clicking on checkboxes.
+/// </summary>
+/// 
+/// See also:
+/// http://stackoverflow.com/questions/17356976/treeview-with-checkboxes-not-processing-clicks-correctly
+/// http://stackoverflow.com/questions/14647216/c-sharp-treeview-ignore-double-click-only-at-checkbox
+class NewTreeView : TreeView
+{
+    protected override void WndProc(ref Message m)
+    {
+        if (m.Msg == 0x203) // identified double click
+        {
+            var local_pos = PointToClient(Cursor.Position);
+            var hit_test_info = HitTest(local_pos);
+
+            if (hit_test_info.Location == TreeViewHitTestLocations.StateImage)
+            {
+                m.Msg = 0x201; // if checkbox was clicked, turn into single click
             }
+
+            base.WndProc(ref m);
+        }
+        else
+        {
+            base.WndProc(ref m);
         }
     }
 }

--- a/src/LiveSplit.ScriptableAutoSplit/Factory.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/Factory.cs
@@ -1,23 +1,23 @@
 ﻿using System;
+
 using LiveSplit.Model;
 using LiveSplit.UI.Components;
 
 [assembly: ComponentFactory(typeof(Factory))]
 
-namespace LiveSplit.UI.Components
+namespace LiveSplit.UI.Components;
+
+public class Factory : IComponentFactory
 {
-    public class Factory : IComponentFactory
-    {
-        public string ComponentName => "Scriptable Auto Splitter";
-        public string Description => "Allows scripts written in the ASL language to define the splitting behaviour.";
-        public ComponentCategory Category => ComponentCategory.Control;
-        public Version Version => Version.Parse("1.8.29");
+    public string ComponentName => "Scriptable Auto Splitter";
+    public string Description => "Allows scripts written in the ASL language to define the splitting behaviour.";
+    public ComponentCategory Category => ComponentCategory.Control;
+    public Version Version => Version.Parse("1.8.29");
 
-        public string UpdateName => ComponentName;
-        public string UpdateURL => "http://livesplit.org/update/";
-        public string XMLURL => "http://livesplit.org/update/Components/update.LiveSplit.ScriptableAutoSplit.xml";
+    public string UpdateName => ComponentName;
+    public string UpdateURL => "http://livesplit.org/update/";
+    public string XMLURL => "http://livesplit.org/update/Components/update.LiveSplit.ScriptableAutoSplit.xml";
 
-        public IComponent Create(LiveSplitState state) => new ASLComponent(state);
-        public IComponent Create(LiveSplitState state, string script) => new ASLComponent(state, script);
-    }
+    public IComponent Create(LiveSplitState state) => new ASLComponent(state);
+    public IComponent Create(LiveSplitState state, string script) => new ASLComponent(state, script);
 }

--- a/src/LiveSplit.ScriptableAutoSplit/Factory.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/Factory.cs
@@ -18,6 +18,13 @@ public class Factory : IComponentFactory
     public string UpdateURL => "http://livesplit.org/update/";
     public string XMLURL => "http://livesplit.org/update/Components/update.LiveSplit.ScriptableAutoSplit.xml";
 
-    public IComponent Create(LiveSplitState state) => new ASLComponent(state);
-    public IComponent Create(LiveSplitState state, string script) => new ASLComponent(state, script);
+    public IComponent Create(LiveSplitState state)
+    {
+        return new ASLComponent(state);
+    }
+
+    public IComponent Create(LiveSplitState state, string script)
+    {
+        return new ASLComponent(state, script);
+    }
 }

--- a/src/LiveSplit.ScriptableAutoSplit/LiveSplit.ScriptableAutoSplit.csproj
+++ b/src/LiveSplit.ScriptableAutoSplit/LiveSplit.ScriptableAutoSplit.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Irony" Version="1.1.0" />
+    <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Parent PR: https://github.com/LiveSplit/LiveSplit/pull/2533

### Description

* Introduces an `.editorconfig` file to enforce consistent style rules.
* Upgrades the language version to C# 12 (most recent stable).
* Adds `PolySharp` to allow for support of some language features which require runtime support (`Index` & `Range` operators).
* Fixes some warnings.
