### PR TITLE
Give autosplitters the ability to use System.Text.Json

### DIFF
--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLMethod.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLMethod.cs
@@ -50,6 +50,8 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Threading;
 using System.Windows.Forms;
 using LiveSplit.ComponentUtil;
@@ -90,6 +92,8 @@ public class CompiledScript
         parameters.ReferencedAssemblies.Add("System.Data.dll");
         parameters.ReferencedAssemblies.Add("System.Data.DataSetExtensions.dll");
         parameters.ReferencedAssemblies.Add("System.Drawing.dll");
+        parameters.ReferencedAssemblies.Add("System.Memory.dll");
+        parameters.ReferencedAssemblies.Add("System.Text.Json.dll");
         parameters.ReferencedAssemblies.Add("System.Windows.Forms.dll");
         parameters.ReferencedAssemblies.Add("System.Xml.dll");
         parameters.ReferencedAssemblies.Add("System.Xml.Linq.dll");


### PR DESCRIPTION
In my JR's autosplitter, I had to use reflection to access System.Text.Json and System.Text.Json.Nodes so I didn't have to hard-code version differences, instead putting them all in a json, which is very ugly and a lot of work.

This PR gives autosplitters access to System.Text.Json and System.Text.Json.Nodes, and I'd love if this were to be added.
<img width="1140" height="309" alt="image" src="https://github.com/user-attachments/assets/0e31aabd-0a9a-4b4b-b67e-bb3abb3e1eb4" />
<img width="312" height="218" alt="image" src="https://github.com/user-attachments/assets/dabfb86a-1d23-4451-a63f-b8da0fe2c2e9" />
