### PR TITLE
Fix Roslyn script compilation

### DIFF
--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLMethod.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLMethod.cs
@@ -33,9 +33,9 @@ public class ASLMethod
             throw new ArgumentNullException(nameof(code));
         }
 
-        if (scriptLine < 1)
+        if (scriptLine < 0)
         {
-            throw new ArgumentOutOfRangeException(nameof(scriptLine), "Must be greater than or equal to 1.");
+            throw new ArgumentOutOfRangeException(nameof(scriptLine), "Must be positive.");
         }
 
         Name = name;
@@ -50,7 +50,6 @@ public class ASLMethod
             using System.Dynamic;
             using System.IO;
             using System.Linq;
-            using System.Memory;
             using System.Reflection;
             using System.Text;
             using System.Text.Json;

--- a/src/LiveSplit.ScriptableAutoSplit/LiveSplit.ScriptableAutoSplit.csproj
+++ b/src/LiveSplit.ScriptableAutoSplit/LiveSplit.ScriptableAutoSplit.csproj
@@ -14,9 +14,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Basic.Reference.Assemblies" Version="1.8.8" />
+    <PackageReference Include="Basic.Reference.Assemblies" Version="1.8.10" />
     <PackageReference Include="Irony" Version="1.5.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
     <PackageReference Include="PolySharp" Version="1.16.0" PrivateAssets="all" />
   </ItemGroup>
 


### PR DESCRIPTION
Removes the incorrect `using System.Memory`, target newer package versions.  
Also relaxes the scriptLine check due to an asl-help quirk that I don't want affecting users.

See also: https://github.com/LiveSplit/LiveSplit/pull/2719