### PR TITLE
Compile ASL scripts unoptimized so reported line numbers are the author's

### DIFF
--- a/src/LiveSplit.ScriptableAutoSplit/ASL/ASLMethod.cs
+++ b/src/LiveSplit.ScriptableAutoSplit/ASL/ASLMethod.cs
@@ -84,7 +84,7 @@ public class ASLMethod
 
         var compilation_options = new CSharpCompilationOptions(
             OutputKind.DynamicallyLinkedLibrary,
-            optimizationLevel: OptimizationLevel.Release,
+            optimizationLevel: OptimizationLevel.Debug,
             allowUnsafe: true);
 
         var compilation = CSharpCompilation.Create(


### PR DESCRIPTION
`ASLMethod` compiles every action with `OptimizationLevel.Release`. An optimized build's sequence points do not map back to the statement that produced them, so the line numbers a script author sees are wrong.

The same script, a `NullReferenceException` thrown on line 13:

| | reported |
| --- | --- |
| `Release` (current) | `at ASL line 8 in 'startup'` |
| `Debug` | `at ASL line 13 in 'startup'` |

Reading a frame directly with `new StackTrace(true).GetFrame(0).GetFileLineNumber()` from inside an action shows the same thing. Statements on lines 7, 8 and 12 report 7, 8 and 12 under `Debug`; under `Release` statements on lines 18, 19 and 23 report 19, 23 and 26, so two adjacent statements can land four apart. The frame's file name is empty either way, so the `#line` mapping and the portable PDB were already doing their job.

### What it costs

`OptimizationLevel.Debug` emits unoptimized IL and a `DebuggableAttribute` that also stops the JIT optimizing, so it is worth being concrete. Compiling the generated wrapper both ways and calling it 3000 times, three runs:

| | Release | Debug |
| --- | --- | --- |
| dynamic member access, what an action actually does | 1.30 - 1.46 us | 1.33 - 1.47 us |
| tight arithmetic, 50000 iterations | 25.7 - 28.2 us | 92.6 - 93.0 us |
| compile time, both warm | 123 - 131 ms | 6 ms |

The runtime cost falls entirely on arithmetic. An action's work is dynamic member access, where the call sites dominate and the optimizer has nothing to do, and even the pathological loop is 93 us against a 60 fps frame. Compiling gets roughly twenty times faster, which is script load time.

Two caveats on those numbers: the first compile in each run absorbs Roslyn's own warmup and `Release` runs first, so the fair compile comparison is the second row; and the benchmark compiles a replica of the generated wrapper rather than driving `ASLMethod` itself.
